### PR TITLE
Handle multiple spaces when counting words

### DIFF
--- a/src/Helpers/countWords.js
+++ b/src/Helpers/countWords.js
@@ -1,6 +1,6 @@
 const countWords = (string) => {
   if (string) {
-    return string.split(" ").length;
+    return string.trim().split(/\s+/).length;
   } else {
     return 0;
   }

--- a/src/Helpers/countWords.test.js
+++ b/src/Helpers/countWords.test.js
@@ -10,8 +10,12 @@ describe("countWords", () => {
     expect(countWords("The house is 120 years old.")).toEqual(6);
   });
 
+  it("counts words with special characters", () => {
+    expect(countWords("The Cat's meow. In-between states.")).toEqual(5);
+  });
+
   it("does not include whitespace, tabs, or newlines in word count", () => {
-    expect(countWords("\n\tThat is       great!\n")).toEqual(3);
+    expect(countWords(" \n\tThat is       great!\n ")).toEqual(3);
   });
 
   it("returns zero given empty string", () => {


### PR DESCRIPTION
I wrote a test a little bit ago for the `countWords` function. This get's the test to pass and adds another test case.