### PR TITLE
Rename theme css vars to match figma names

### DIFF
--- a/src/Components/design/Accordion/Accordion.css
+++ b/src/Components/design/Accordion/Accordion.css
@@ -1,5 +1,5 @@
 .accordion > .accordion-item {
-  border-bottom: 1px solid var(--contrast-10-light);
+  border-bottom: 1px solid var(--contrast-10);
 }
 
 .accordion > .accordion-item:last-child {

--- a/src/Components/design/Button/Button.css
+++ b/src/Components/design/Button/Button.css
@@ -18,39 +18,30 @@
 }
 
 .button--contained {
-  color: var(--contrast-light);
+  color: var(--primary-contrast);
+}
+.button--contained:hover:not(:active) {
+  opacity: 0.85;
 }
 
 .button--contained.button--primary {
   background-color: var(--primary);
 }
-.button--contained.button--primary:hover:not(:active) {
-  background-color: var(--primary-contrast);
-}
 
 .button--contained.button--success {
   background-color: var(--success);
-}
-.button--contained.button--success:hover:not(:active) {
-  background-color: var(--success-contrast);
 }
 
 .button--contained.button--error {
   background-color: var(--error);
 }
-.button--contained.button--error:hover:not(:active) {
-  background-color: var(--error-contrast);
-}
 
 .button--contained.button--contrast {
-  background-color: var(--contrast-dark);
+  background-color: var(--contrast-100);
 }
-/* .button--contained.button--contrast:hover:not(:active) {
-  background-color: TODO
-} */
 
 .button--outlined {
-  background-color: var(--contrast-grey);
+  background-color: var(--contrast-5);
 }
 
 .button--text {
@@ -59,26 +50,26 @@
 
 .button--outlined.button--primary,
 .button--text.button--primary {
-  color: var(--primary-contrast);
+  color: var(--primary-text);
 }
 
 .button--outlined.button--success,
 .button--text.button--success {
-  color: var(--success-contrast);
+  color: var(--success-text);
 }
 
 .button--outlined.button--error,
 .button--text.button--error {
-  color: var(--error-contrast);
+  color: var(--error-text);
 }
 
 .button--outlined.button--contrast,
 .button--text.button--contrast {
-  color: var(--contrast-dark);
+  color: var(--contrast-100);
 }
 
 .button.button--disabled {
-  background-color: rgba(0, 0, 0, 0.3);
+  opacity: 0.5;
 }
 
 .button--none {

--- a/src/Components/design/Checkbox/Checkbox.css
+++ b/src/Components/design/Checkbox/Checkbox.css
@@ -32,14 +32,14 @@ svg.checkbox__check {
 }
 
 .checkbox__input:checked ~ .checkbox__check {
-  color: var(--contrast-light);
+  color: var(--primary-contrast);
 }
 
 .checkbox__background {
   position: absolute;
   width: 1rem;
   height: 1rem;
-  background-color: var(--contrast-20-light);
+  background-color: var(--contrast-20);
   border-radius: 4px;
 }
 

--- a/src/Components/design/Input/Input.css
+++ b/src/Components/design/Input/Input.css
@@ -3,13 +3,13 @@
   margin-bottom: 7px;
   font-weight: var(--font-weight-bold);
   font-size: var(--font-size-small);
-  color: var(--secondary-text-light);
+  color: var(--contrast-70);
   line-height: normal;
 }
 
 .input {
   border-radius: 4px;
   border: 0;
-  background-color: var(--background-grey-light);
+  background-color: var(--contrast-10);
   padding: 7px 10px;
 }

--- a/src/Components/design/theme.css
+++ b/src/Components/design/theme.css
@@ -1,19 +1,32 @@
 :root {
   --primary: #009285;
-  --primary-contrast: #3ea499;
-  --primary-contrast-alt: #005f54;
-  --secondary: rgba(224, 39, 128, 1);
-  --secondary-alt: rgba(236, 95, 163, 1);
-  --secondary-text-light: rgba(27, 43, 65, 0.72);
-  --success: #15c15d;
-  --success-contrast: #00a344;
+  --primary-text: #3ea499;
+  --primary-contrast: rgba(255, 255, 255, 1);
+  --secondary: #e02780;
+  --secondary-text: #ec5fa3;
   --error: #ff4238;
-  --error-contrast: #f52419;
-  --contrast-dark: #192434;
-  --contrast-dark-alt: rgba(24, 39, 58, 0.94);
-  --contrast-grey: rgba(25, 59, 103, 0.05);
-  --contrast-light: #ffffff;
-  --contrast-10-light: rgba(26, 56, 96, 0.1);
-  --contrast-20-light: rgba(28, 55, 90, 0.16);
-  --background-grey-light: rgba(26, 56, 96, 0.1);
+  --error-text: #f52419;
+  --success: #15c15d;
+  --success-text: hsl(145, 100%, 32%);
+  --base: #ffffff;
+  --base-contrast-5: linear-gradient(
+      0deg,
+      rgba(25, 59, 103, 0.05),
+      rgba(25, 59, 103, 0.05)
+    ),
+    #ffffff;
+  --contrast-100: #192434;
+  --contrast-90: rgba(24, 39, 58, 0.94);
+  --contrast-80: rgba(26, 41, 61, 0.83);
+  --contrast-70: rgba(27, 43, 65, 0.72);
+  --contrast-60: rgba(28, 46, 69, 0.6);
+  --contrast-50: rgba(28, 48, 74, 0.5);
+  --contrast-40: rgba(28, 50, 79, 0.38);
+  --contrast-30: rgba(28, 52, 84, 0.26);
+  --contrast-20: rgba(28, 55, 90, 0.16);
+  --contrast-10: rgba(26, 56, 96, 0.1);
+  --contrast-5: rgba(25, 59, 103, 0.05);
+  --heading-text: #192434;
+  --body-text: rgba(24, 39, 58, 0.94);
+  --disabled-text: rgba(28, 52, 84, 0.26);
 }

--- a/src/Components/design/theme.css
+++ b/src/Components/design/theme.css
@@ -30,3 +30,24 @@
   --body-text: rgba(24, 39, 58, 0.94);
   --disabled-text: rgba(28, 52, 84, 0.26);
 }
+
+body {
+  color: var(--body-text);
+  background-color: var(--base);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--heading-text);
+}
+
+a {
+  color: var(--primary-text);
+}
+a:visited {
+  color: var(--primary-contrast-alt);
+}

--- a/src/Components/design/typography.css
+++ b/src/Components/design/typography.css
@@ -20,7 +20,6 @@ body {
   font-family: "Rubik", sans-serif;
   font-weight: var(--font-weight-normal);
   line-height: 1.75;
-  color: var(--body-text);
 }
 
 h1,
@@ -32,7 +31,6 @@ h6 {
   margin: 3rem 0 1.38rem;
   font-weight: var(--font-weight-normal);
   line-height: 1.3;
-  color: var(--heading-text);
 }
 
 h1,
@@ -76,13 +74,6 @@ small {
 
 p {
   margin-bottom: 1rem;
-}
-
-a {
-  color: var(--primary-text);
-}
-a:visited {
-  color: var(--primary-contrast-alt);
 }
 
 button,

--- a/src/Components/design/typography.css
+++ b/src/Components/design/typography.css
@@ -20,7 +20,7 @@ body {
   font-family: "Rubik", sans-serif;
   font-weight: var(--font-weight-normal);
   line-height: 1.75;
-  color: var(--contrast-dark-alt);
+  color: var(--body-text);
 }
 
 h1,
@@ -32,7 +32,7 @@ h6 {
   margin: 3rem 0 1.38rem;
   font-weight: var(--font-weight-normal);
   line-height: 1.3;
-  color: var(--contrast-dark);
+  color: var(--heading-text);
 }
 
 h1,
@@ -79,7 +79,7 @@ p {
 }
 
 a {
-  color: var(--primary-contrast);
+  color: var(--primary-text);
 }
 a:visited {
   color: var(--primary-contrast-alt);


### PR DESCRIPTION
Closes #212 

To avoid confusion and extra thinking when adding/changing/using colors, this renames our css color vars to match the names in the figma design.