### PR TITLE
Add styling to description lists

### DIFF
--- a/src/Components/design/Typography.stories.jsx
+++ b/src/Components/design/Typography.stories.jsx
@@ -7,6 +7,16 @@ export default {
 export const Typography = () => (
   <>
     <h1>Heading 1</h1>
+    <dl>
+      <dt>Funding Organization</dt>
+      <dd>The Good Place</dd>
+
+      <dt>RFP Website</dt>
+      <dd>goodorbad.com/newneighborhoods</dd>
+
+      <dt>Purpose</dt>
+      <dd>Moral Testing</dd>
+    </dl>
     <p>
       <b>Lorem ipsum dolor sit amet</b>, consectetur adipiscing elit, sed do
       eiusmod tempor incididunt ut labore et dolore magna aliqua.{" "}

--- a/src/Components/design/typography.css
+++ b/src/Components/design/typography.css
@@ -95,3 +95,13 @@ input {
   font-family: inherit;
   font-size: inherit;
 }
+
+dl dt {
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+}
+
+dl dd {
+  margin: 0 0 1rem 0;
+}


### PR DESCRIPTION
Closes #208 


Adds minimal styling to description lists to match design in figma. I decided not to make an entire component because I felt it wasn't necessary. Lmk what you think!

![](https://user-images.githubusercontent.com/23223956/126248642-f40f1fbd-678c-490b-8da2-71c7a40a5cf3.png)

