### PR TITLE
Convert eslint errors to warning in create react app error overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "rest-hooks": "^5.3.2"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts start",
+    "start": "PORT=3001 ESLINT_NO_DEV_ERRORS=true react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Currently when there's an eslint error in the code this shows up in the browser:

![image](https://user-images.githubusercontent.com/23223956/144735345-242271cc-d2e0-48c1-8082-82098c04ab0f.png)

This lengthens the feedback loop of developing/quickly trying out things and can be frustrating. 

This turns off that overlay through setting the an environment variable create react app looks for.

This won't affect linting in the editor or in CI. So it's still enforced, just now we won't be blocked if we create an unused variable :)