### PR TITLE
Handle missing last name for UserIcon

### DIFF
--- a/src/Components/Helpers/UserIcon.js
+++ b/src/Components/Helpers/UserIcon.js
@@ -19,12 +19,12 @@ export default function UserIcon(props) {
 
   return (
     <div className="user-icon" aria-hidden="true" style={{ backgroundColor }}>
-      {firstName[0] + lastName[0]}
+      {firstName[0] + (lastName?.[0] || "")}
     </div>
   );
 }
 
 UserIcon.propTypes = {
   firstName: PropTypes.string.isRequired,
-  lastName: PropTypes.string.isRequired,
+  lastName: PropTypes.string,
 };


### PR DESCRIPTION
If a user is missing a last_name, the UserIcon component renders undefined. This resolves that.

Before
![image](https://user-images.githubusercontent.com/23223956/151589890-9f634d6d-0573-4858-8bf4-dfc5cafe5951.png)

After
![image](https://user-images.githubusercontent.com/23223956/151589995-08f331d6-fc5a-497b-aac8-fff145fcf31a.png)
