### PR TITLE
Fix api client base url for prod

### DIFF
--- a/src/config/apiClient.js
+++ b/src/config/apiClient.js
@@ -1,9 +1,6 @@
 import axios from "axios";
 
-const DEVELOPMENT_API_URL =
-  process.env.REACT_APP_API_URL || "http://localhost:3000";
-const BASE_URL =
-  process.env.NODE_ENV === "development" ? DEVELOPMENT_API_URL : "";
+const BASE_URL = process.env.REACT_APP_API_URL || "http://localhost:3000";
 
 const apiClient = axios.create({
   baseURL: `${BASE_URL}/api/`,


### PR DESCRIPTION
This wasn't using `REACT_APP_API_URL` when `NODE_ENV` was set to production.