### PR TITLE
Force HTTPS and HSTS for production static server

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,0 +1,12 @@
+{
+  "root": "build/",
+  "routes": {
+    "/**": "index.html"
+  },
+  "https_only": true,
+  "headers": {
+    "/**": {
+      "Strict-Transport-Security": "max-age=31557600"
+    }
+  }
+}


### PR DESCRIPTION
This adds a configuration file for the static web service used in production via the create-react-app buildpack.

* In this config I've enabled `https_only` which will [redirect insecure http requests to https.](https://github.com/mars/create-react-app-buildpack#user-content-https-only)
* I've also added [HTTP strict transport security (HSTS) header](https://github.com/mars/create-react-app-buildpack#strict-transport-security-hsts) to all requests as a second way of preventing insecure requests