### PR TITLE
Remove reports option from sidebar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -112,10 +112,6 @@ export default function App() {
                       path="/organizations/:organizationUuid/users"
                       component={StayTunedPage}
                     />
-                    <Route
-                      path="/organizations/:organizationUuid/reports"
-                      component={StayTunedPage}
-                    />
                     <Redirect to="/organizations/:organizationUuid/dashboard" />
                   </Switch>
                 </Suspense>

--- a/src/Components/design/Sidebar/Sidebar.js
+++ b/src/Components/design/Sidebar/Sidebar.js
@@ -13,77 +13,36 @@ import {
 import "./Sidebar.css";
 import CurrentOrganizationLink from "../../Helpers/CurrentOrganizationLink";
 
+const LINKS = [
+  { icon: <MdHome />, title: "Dashboard", path: "/dashboard" },
+  { icon: <MdLocalAtm />, title: "Grants", path: "/grants" },
+  { icon: <MdExtension />, title: "Boilerplates", path: "/boilerplates" },
+  {
+    icon: <MdAccountBalance />,
+    title: "Funding Organizations",
+    path: "/funding_orgs",
+  },
+  { icon: <MdFormatListBulleted />, title: "Categories", path: "/categories" },
+  { icon: <MdPerson />, title: "Users", path: "/users" },
+];
+
 export default function Sidebar(props) {
   return (
     <nav className={clsx(props.className, "sidebar")}>
       <ul className="sidebar__list">
-        <li>
-          <CurrentOrganizationLink
-            as={NavLink}
-            className="sidebar__navitem"
-            activeClassName="sidebar__navitem--selected"
-            to="/dashboard"
-          >
-            <MdHome />
-            Dashboard
-          </CurrentOrganizationLink>
-        </li>
-
-        <li>
-          <CurrentOrganizationLink
-            as={NavLink}
-            className="sidebar__navitem"
-            activeClassName="sidebar__navitem--selected"
-            to="/grants"
-          >
-            <MdLocalAtm />
-            Grants
-          </CurrentOrganizationLink>
-        </li>
-        <li>
-          <CurrentOrganizationLink
-            as={NavLink}
-            className="sidebar__navitem"
-            activeClassName="sidebar__navitem--selected"
-            to="/boilerplates"
-          >
-            <MdExtension />
-            Boilerplates
-          </CurrentOrganizationLink>
-        </li>
-        <li>
-          <CurrentOrganizationLink
-            as={NavLink}
-            className="sidebar__navitem"
-            activeClassName="sidebar__navitem--selected"
-            to="/funding_orgs"
-          >
-            <MdAccountBalance />
-            Funding Organizations
-          </CurrentOrganizationLink>
-        </li>
-        <li>
-          <CurrentOrganizationLink
-            as={NavLink}
-            className="sidebar__navitem"
-            activeClassName="sidebar__navitem--selected"
-            to="/categories"
-          >
-            <MdFormatListBulleted />
-            Categories
-          </CurrentOrganizationLink>
-        </li>
-        <li>
-          <CurrentOrganizationLink
-            as={NavLink}
-            className="sidebar__navitem"
-            activeClassName="sidebar__navitem--selected"
-            to="/users"
-          >
-            <MdPerson />
-            Users
-          </CurrentOrganizationLink>
-        </li>
+        {LINKS.map(({ icon, title, path }) => (
+          <li key={title}>
+            <CurrentOrganizationLink
+              as={NavLink}
+              className="sidebar__navitem"
+              activeClassName="sidebar__navitem--selected"
+              to={path}
+            >
+              {icon}
+              {title}
+            </CurrentOrganizationLink>
+          </li>
+        ))}
       </ul>
     </nav>
   );

--- a/src/Components/design/Sidebar/Sidebar.js
+++ b/src/Components/design/Sidebar/Sidebar.js
@@ -6,7 +6,6 @@ import {
   MdHome,
   MdLocalAtm,
   MdExtension,
-  MdBarChart,
   MdAccountBalance,
   MdFormatListBulleted,
   MdPerson,
@@ -50,17 +49,6 @@ export default function Sidebar(props) {
           >
             <MdExtension />
             Boilerplates
-          </CurrentOrganizationLink>
-        </li>
-        <li>
-          <CurrentOrganizationLink
-            as={NavLink}
-            className="sidebar__navitem"
-            activeClassName="sidebar__navitem--selected"
-            to="/reports"
-          >
-            <MdBarChart />
-            Reports
           </CurrentOrganizationLink>
         </li>
         <li>


### PR DESCRIPTION
## 🤺 Summary
Closes #373 

This removes the "Reports" link from the sidebar since reports are grant-level and do not need to be global at this time.

## 📝 Checklist
<!-- Check steps as necessary - this list is a reminder -->
* [x] Are tests & linter passing?
* [x] Are relevant tickets linked to this PR?
* [x] Are reviews assigned to this PR?

## 🔬 Steps to test
Navigate to an organization, from there you should not see the "Reports" option in the sidebar.