### PR TITLE
352/replace uuids with ids

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,25 +40,25 @@ export default function App() {
           <Route path="/reset_password" component={ResetPassword} />
           {/* <Route path="/forgot_password" component={ForgotPassword} /> */}
           <CurrentOrganizationProvider>
-            <PrivateRoute path="/organizations/:organizationUuid/">
+            <PrivateRoute path="/organizations/:organizationId/">
               <OrganizationLayout>
                 <Suspense fallback={<Spinner size="md" centered />}>
                   <Switch>
                     <Route
-                      path="/organizations/:organizationUuid/dashboard"
+                      path="/organizations/:organizationId/dashboard"
                       component={Dashboard}
                     />
                     <PrivateRoute
-                      path="/organizations/:organizationUuid/grants/:grantUuid/edit"
+                      path="/organizations/:organizationId/grants/:grantId/edit"
                       component={GrantEdit}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/grants/:grantUuid/copy"
+                      path="/organizations/:organizationId/grants/:grantId/copy"
                       component={GrantCopy}
                     />
                     <Route
                       exact
-                      path="/organizations/:organizationUuid/grants/:grantUuid"
+                      path="/organizations/:organizationId/grants/:grantId"
                       component={() => (
                         <PasteBoilerplateContentPopoutProvider>
                           <GrantsShow />
@@ -66,53 +66,53 @@ export default function App() {
                       )}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/grants-new"
+                      path="/organizations/:organizationId/grants-new"
                       component={GrantsNew}
                     />
                     <Route
                       exact
                       path={
-                        "/organizations/:organizationUuid/grants/:grantUuid/reports/:reportUuid"
+                        "/organizations/:organizationId/grants/:grantId/reports/:reportId"
                       }
                       component={ReportsShow}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/grants/:grantUuid/reports-new"
+                      path="/organizations/:organizationId/grants/:grantId/reports-new"
                       component={ReportsNew}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/grants/"
+                      path="/organizations/:organizationId/grants/"
                       component={GrantsIndex}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/boilerplates/:boilerplateUuid"
+                      path="/organizations/:organizationId/boilerplates/:boilerplateId"
                       component={BoilerplatesShow}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/boilerplates-new"
+                      path="/organizations/:organizationId/boilerplates-new"
                       component={BoilerplatesNew}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/boilerplates"
+                      path="/organizations/:organizationId/boilerplates"
                       component={BoilerplatesIndex}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/categories"
+                      path="/organizations/:organizationId/categories"
                       component={CategoriesIndex}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/funding_orgs-new"
+                      path="/organizations/:organizationId/funding_orgs-new"
                       component={FundingOrgNew}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/funding_orgs"
+                      path="/organizations/:organizationId/funding_orgs"
                       component={FundingOrgsIndex}
                     />
                     <Route
-                      path="/organizations/:organizationUuid/users"
+                      path="/organizations/:organizationId/users"
                       component={StayTunedPage}
                     />
-                    <Redirect to="/organizations/:organizationUuid/dashboard" />
+                    <Redirect to="/organizations/:organizationId/dashboard" />
                   </Switch>
                 </Suspense>
               </OrganizationLayout>

--- a/src/Components/Boilerplates/BoilerplateForm.js
+++ b/src/Components/Boilerplates/BoilerplateForm.js
@@ -18,7 +18,7 @@ export default function BoilerplateForm(props) {
     title: props.boilerplate?.title || "",
     text: props.boilerplate?.text || "",
     html: props.boilerplate?.text || "",
-    categoryUuid: props.boilerplate?.categoryUuid || "",
+    categoryId: props.boilerplate?.categoryId || "",
   });
   const quillEl = useRef(null);
   const { data: categories } = useQuery("getCategories", () =>
@@ -44,7 +44,7 @@ export default function BoilerplateForm(props) {
     if (createdCategory) {
       setBoilerplateFields({
         ...boilerplateFields,
-        categoryUuid: createdCategory.uuid,
+        categoryId: createdCategory.id,
       });
     }
   };
@@ -57,15 +57,15 @@ export default function BoilerplateForm(props) {
           onClickAltLabel={() => setShowingCategoriesNew(true)}
           labelText="Category"
           placeholder="Select a Category"
-          value={boilerplateFields.categoryUuid}
+          value={boilerplateFields.categoryId}
           options={categories.map((category) => ({
-            value: category.uuid,
+            value: category.id,
             label: category.name,
           }))}
           onChange={(option) =>
             setBoilerplateFields({
               ...boilerplateFields,
-              categoryUuid: option.value,
+              categoryId: option.value,
             })
           }
         />

--- a/src/Components/Boilerplates/BoilerplatesIndex.js
+++ b/src/Components/Boilerplates/BoilerplatesIndex.js
@@ -41,7 +41,7 @@ export default function BoilerplatesIndex() {
     {
       Header: "Title",
       accessor: (boilerplate) => (
-        <CurrentOrganizationLink to={`/boilerplates/${boilerplate.uuid}`}>
+        <CurrentOrganizationLink to={`/boilerplates/${boilerplate.id}`}>
           {boilerplate.title}
         </CurrentOrganizationLink>
       ),
@@ -83,7 +83,7 @@ export default function BoilerplatesIndex() {
   }
 
   const openBoilerplateShow = (row) => {
-    history.push(buildOrganizationsLink(`/boilerplates/${row.original.uuid}`));
+    history.push(buildOrganizationsLink(`/boilerplates/${row.original.id}`));
   };
 
   return (
@@ -100,7 +100,7 @@ export default function BoilerplatesIndex() {
         />
         <Button
           as={Link}
-          to={`/organizations/${currentOrganization.uuid}/boilerplates-new/`}
+          to={`/organizations/${currentOrganization.id}/boilerplates-new/`}
         >
           Add New Boilerplates
         </Button>

--- a/src/Components/Boilerplates/BoilerplatesNew.js
+++ b/src/Components/Boilerplates/BoilerplatesNew.js
@@ -24,7 +24,7 @@ export default function BoilerplatesNew() {
   );
 
   const handleCancel = () => {
-    history.push(`/organizations/${currentOrganization.uuid}/boilerplates`);
+    history.push(`/organizations/${currentOrganization.id}/boilerplates`);
   };
 
   const { mutate: createBoilerplate } = useMutation(
@@ -32,14 +32,14 @@ export default function BoilerplatesNew() {
       BoilerplatesService.createBoilerplate(organizationClient, {
         title: newBoilerplateFields.title,
         text: newBoilerplateFields.html,
-        categoryUuid: newBoilerplateFields.categoryUuid,
+        categoryId: newBoilerplateFields.categoryId,
         wordcount: countWords(newBoilerplateFields.text),
       }),
     {
       onSuccess: (createdBoilerplate) => {
         alert("Boilerplate created!");
         history.push(
-          `/organizations/${currentOrganization.uuid}/boilerplates/${createdBoilerplate.uuid}`
+          `/organizations/${currentOrganization.id}/boilerplates/${createdBoilerplate.id}`
         );
       },
     }

--- a/src/Components/Boilerplates/BoilerplatesShow.js
+++ b/src/Components/Boilerplates/BoilerplatesShow.js
@@ -11,14 +11,14 @@ import "./BoilerplatesShow.css";
 
 export default function BoilerplatesShow() {
   const { currentOrganization, organizationClient } = useCurrentOrganization();
-  const { boilerplateUuid } = useParams();
+  const { boilerplateId } = useParams();
   const {
     data: boilerplate,
     isError,
     isLoading,
     error,
   } = useQuery("getBoilerplate", () =>
-    BoilerplatesService.getBoilerplate(organizationClient, boilerplateUuid)
+    BoilerplatesService.getBoilerplate(organizationClient, boilerplateId)
   );
   const [editingBoilerplate, setEditingBoilerplate] = useState(false);
 
@@ -26,7 +26,7 @@ export default function BoilerplatesShow() {
     (newBoilerplateFields) =>
       BoilerplatesService.updateBoilerplate(
         organizationClient,
-        newBoilerplateFields.uuid,
+        newBoilerplateFields.id,
         newBoilerplateFields
       ),
     {
@@ -60,9 +60,9 @@ export default function BoilerplatesShow() {
           headerText={boilerplate.title}
           wordcount={boilerplate.wordcount}
           categoryText={boilerplate.categoryName}
-          breadCrumbLink={`/organizations/${currentOrganization.uuid}/boilerplates/`}
-          editLink={`/boilerplates/${boilerplate.uuid}/edit/`}
-          // copyLink={`/boilerplates/${boilerplate.uuid}/copy/`}
+          breadCrumbLink={`/organizations/${currentOrganization.id}/boilerplates/`}
+          editLink={`/boilerplates/${boilerplate.id}/edit/`}
+          // copyLink={`/boilerplates/${boilerplate.id}/copy/`}
           setIsOpen={setEditingBoilerplate}
         />
         <Container className="boilerplates-show__text-container" centered>

--- a/src/Components/Categories/CategoriesIndex.js
+++ b/src/Components/Categories/CategoriesIndex.js
@@ -52,12 +52,12 @@ export default function CategoriesIndex() {
     try {
       switch (option.value) {
         case "REMOVE_FROM_ARCHIVED":
-          await updateCategory(organizationClient, category.uuid, {
+          await updateCategory(organizationClient, category.id, {
             archived: false,
           });
           break;
         case "MARK_AS_ARCHIVED":
-          await updateCategory(organizationClient, category.uuid, {
+          await updateCategory(organizationClient, category.id, {
             archived: true,
           });
           break;

--- a/src/Components/Categories/CategoriesNew.js
+++ b/src/Components/Categories/CategoriesNew.js
@@ -14,24 +14,24 @@ export default function CategoriesNew(props) {
     event.preventDefault();
     const newCategory = {
       name: name,
-      organizationUuid: currentOrganization.uuid,
+      organizationId: currentOrganization.id,
     };
-    if (currentOrganization.uuid) {
+    if (currentOrganization.id) {
       createCategory(organizationClient, newCategory)
         .then((category) => {
-          // const { createdAt, updatedAt, uuid, name, organizationUuid } =
+          // const { createdAt, updatedAt, id, name, organizationId } =
           //   category;
           // props.setCategories([
           //   ...props.currentCategories,
           //   {
           //     createdAt,
           //     updatedAt,
-          //     uuid,
+          //     id,
           //     name,
-          //     organizationUuid,
+          //     organizationId,
           //   },
           // ]);
-          props.onClose(category.uuid);
+          props.onClose(category.id);
         })
         .catch((error) => {
           console.error("category creation error", error);

--- a/src/Components/Categories/CategoryEdit.js
+++ b/src/Components/Categories/CategoryEdit.js
@@ -9,9 +9,9 @@ export default function CategoryEdit(props) {
   const { organizationClient } = useCurrentOrganization();
 
   const handleSubmit = (categoryFields) => {
-    CategoriesService.updateCategory(organizationClient, props.category.uuid, {
+    CategoriesService.updateCategory(organizationClient, props.category.id, {
       ...categoryFields,
-      organizationUuid: organizationClient,
+      organizationId: organizationClient,
     })
       .then(() => {
         props.onClose();
@@ -28,7 +28,7 @@ export default function CategoryEdit(props) {
   const handleDelete = () => {
     // console.log("you deleted this category!");
     // if (confirm(`Are you sure you want to delete this category?`)) {
-    //   CategoriesService.deleteCategory(organizationClient, props.category.uuid)
+    //   CategoriesService.deleteCategory(organizationClient, props.category.id)
     //     .then(() => {
     //       alert("Category deleted!");
     //       props.onClose();
@@ -42,13 +42,9 @@ export default function CategoryEdit(props) {
     // }
     // eslint-disable-next-line no-restricted-globals
     if (confirm(`Are you sure you want to delete this category?`)) {
-      CategoriesService.updateCategory(
-        organizationClient,
-        props.category.uuid,
-        {
-          archived: true,
-        }
-      )
+      CategoriesService.updateCategory(organizationClient, props.category.id, {
+        archived: true,
+      })
         .then(() => {
           alert("Category deleted!");
           props.onClose();

--- a/src/Components/Categories/CategoryNew.js
+++ b/src/Components/Categories/CategoryNew.js
@@ -23,7 +23,7 @@ export default function CategoryNew(props) {
   const handleSubmit = (categoryFields) => {
     createCategory({
       ...categoryFields,
-      organizationUuid: currentOrganization.uuid,
+      organizationId: currentOrganization.id,
     });
   };
 

--- a/src/Components/Dashboard.js
+++ b/src/Components/Dashboard.js
@@ -46,7 +46,7 @@ export default function Dashboard() {
         <ul className="dashboard__recent-drafts-list">
           {recentDrafts.map((recentDraftGrant) => (
             <GrantListItem
-              key={recentDraftGrant.uuid}
+              key={recentDraftGrant.id}
               grant={recentDraftGrant}
               icon={MdAccessTime}
             />
@@ -60,7 +60,7 @@ export default function Dashboard() {
         <ul className="dashboard__due-soon-list">
           {dueSoon.map((dueSoonGrant) => (
             <GrantListItem
-              key={dueSoonGrant.uuid}
+              key={dueSoonGrant.id}
               grant={dueSoonGrant}
               icon={MdAlarm}
             />
@@ -86,7 +86,7 @@ export default function Dashboard() {
         </header>
         <ul className="dashboard__users-list">
           {users.map((user) => (
-            <UserListItem key={user.uuid} user={user} />
+            <UserListItem key={user.id} user={user} />
           ))}
         </ul>
       </article>

--- a/src/Components/Dashboard/GrantListItem.js
+++ b/src/Components/Dashboard/GrantListItem.js
@@ -8,7 +8,7 @@ export default function GrantListItem(props) {
 
   return (
     <li className="grant-list-item">
-      <CurrentOrganizationLink to={`/grants/${grant.uuid}`}>
+      <CurrentOrganizationLink to={`/grants/${grant.id}`}>
         <article className="grant">
           <p className="grant__title">{grant.title}</p>
           <div className="grant__deadline">

--- a/src/Components/Dashboard/UserListItem.js
+++ b/src/Components/Dashboard/UserListItem.js
@@ -8,7 +8,7 @@ export default function UserListItem(props) {
 
   return (
     <li className="user-list-item">
-      <CurrentOrganizationLink to={`/users/${user.uuid}`}>
+      <CurrentOrganizationLink to={`/users/${user.id}`}>
         <UserIcon firstName={user.firstName} lastName={user.lastName} />
         {user.firstName} {user.lastName}
       </CurrentOrganizationLink>

--- a/src/Components/FundingOrgs/FundingOrgEdit.js
+++ b/src/Components/FundingOrgs/FundingOrgEdit.js
@@ -11,14 +11,14 @@ export default function FundingOrgEdit(props) {
   const handleSubmit = (fundingOrgFields) => {
     FundingOrgsService.updateFundingOrg(
       organizationClient,
-      props.fundingOrg.uuid,
+      props.fundingOrg.id,
       {
         ...fundingOrgFields,
-        organizationUuid: organizationClient,
+        organizationId: organizationClient,
       }
     )
       .then((fundingOrg) => {
-        if (fundingOrg.uuid) {
+        if (fundingOrg.id) {
           props.onClose();
         }
       })
@@ -36,7 +36,7 @@ export default function FundingOrgEdit(props) {
     if (confirm(`Are you sure you want to delete this funding org?`)) {
       FundingOrgsService.updateFundingOrg(
         organizationClient,
-        props.fundingOrg.uuid,
+        props.fundingOrg.id,
         {
           archived: true,
         }
@@ -56,7 +56,7 @@ export default function FundingOrgEdit(props) {
     // if (confirm(`Are you sure you want to delete this funding org?`)) {
     //   FundingOrgsService.deleteFundingOrg(
     //     organizationClient,
-    //     props.fundingOrg.uuid
+    //     props.fundingOrg.id
     //   )
     //     .then(() => {
     //       alert("Funding org deleted!");

--- a/src/Components/FundingOrgs/FundingOrgEditForm.js
+++ b/src/Components/FundingOrgs/FundingOrgEditForm.js
@@ -14,7 +14,7 @@ export default function FundingOrgsEditForm(props) {
         newName,
         newWebsite,
       },
-      props.fundingOrg.uuid
+      props.fundingOrg.id
     );
   };
 

--- a/src/Components/FundingOrgs/FundingOrgNew.js
+++ b/src/Components/FundingOrgs/FundingOrgNew.js
@@ -12,12 +12,12 @@ export default function FundingOrgNew(props) {
     (newFundingOrgFields) =>
       FundingOrgsService.createFundingOrg(organizationClient, {
         ...newFundingOrgFields,
-        organizationUuid: currentOrganization.uuid,
+        organizationId: currentOrganization.id,
       }),
     {
       onSuccess: (fundingOrg) => {
         alert("Funding org created!");
-        props.onClose(fundingOrg.uuid);
+        props.onClose(fundingOrg.id);
       },
     }
   );

--- a/src/Components/FundingOrgs/FundingOrgsIndex.js
+++ b/src/Components/FundingOrgs/FundingOrgsIndex.js
@@ -56,7 +56,7 @@ export default function FundingOrgsIndex() {
     (newFundingOrgFields) =>
       FundingOrgsService.updateFundingOrg(
         organizationClient,
-        newFundingOrgFields.uuid,
+        newFundingOrgFields.id,
         newFundingOrgFields
       ),
     {
@@ -73,7 +73,7 @@ export default function FundingOrgsIndex() {
   //   createFundingOrg({
   //     title: newFundingOrgFields.title,
   //     text: newFundingOrgFields.html,
-  //     grantUuid: grantUuid,
+  //     grantId: grantId,
   //     sort_order: precedingFundingOrg ? precedingFundingOrg.sortOrder + 1 : 0,
   //     wordcount: countWords(newFundingOrgFields.text),
   //   });
@@ -92,10 +92,10 @@ export default function FundingOrgsIndex() {
     try {
       switch (option.value) {
         case "REMOVE_FROM_ARCHIVED":
-          await updateFundingOrg({ uuid: fundingOrg.uuid, archived: false });
+          await updateFundingOrg({ id: fundingOrg.id, archived: false });
           break;
         case "MARK_AS_ARCHIVED":
-          await updateFundingOrg({ uuid: fundingOrg.uuid, archived: true });
+          await updateFundingOrg({ id: fundingOrg.id, archived: true });
           break;
         case "EDIT":
           openEditFundingOrg(fundingOrg);
@@ -292,7 +292,7 @@ export default function FundingOrgsIndex() {
 //     (newFundingOrgFields) =>
 //       FundingOrgsService.updateFundingOrg(
 //         organizationClient,
-//         newFundingOrgFields.uuid,
+//         newFundingOrgFields.id,
 //         newFundingOrgFields
 //       ),
 //     {
@@ -306,12 +306,12 @@ export default function FundingOrgsIndex() {
 //     try {
 //       switch (option.value) {
 //         case "REMOVE_FROM_ARCHIVED":
-//           await updateFundingOrg(organizationClient, fundingOrg.uuid, {
+//           await updateFundingOrg(organizationClient, fundingOrg.id, {
 //             archived: false,
 //           });
 //           break;
 //         case "MARK_AS_ARCHIVED":
-//           await updateFundingOrg(organizationClient, fundingOrg.uuid, {
+//           await updateFundingOrg(organizationClient, fundingOrg.id, {
 //             archived: true,
 //           });
 //           break;

--- a/src/Components/Grants/GrantCopy.js
+++ b/src/Components/Grants/GrantCopy.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useQuery } from "react-query";
 import { useHistory, useParams } from "react-router-dom";
 import Container from "../design/Container/Container";
@@ -13,8 +13,6 @@ import GrantForm from "./GrantForm";
 import "./GrantCopy.css";
 
 export default function GrantCopy() {
-  const [grant, setGrant] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
   const { organizationClient } = useCurrentOrganization();
   const buildOrganizationsLink = useBuildOrganizationsLink();
   const { grantId } = useParams();
@@ -39,23 +37,12 @@ export default function GrantCopy() {
       });
   };
 
+  const { data: grant } = useQuery("grant", () =>
+    getGrant(organizationClient, grantId)
+  );
   const { data: fundingOrgs } = useQuery("fundingOrgs", () =>
     getAllFundingOrgs(organizationClient)
   );
-
-  useEffect(() => {
-    if (!organizationClient) {
-      return;
-    }
-
-    getGrant(organizationClient, grantId)
-      .then(setGrant)
-      .then(() => setIsLoading(false));
-  }, [grantId, organizationClient]);
-
-  if (isLoading) {
-    return "Loading...";
-  }
 
   return (
     <div className="grant-copy">

--- a/src/Components/Grants/GrantCopy.js
+++ b/src/Components/Grants/GrantCopy.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState } from "react";
+import { useQuery } from "react-query";
 import { useHistory, useParams } from "react-router-dom";
 import Container from "../design/Container/Container";
 import { useCurrentOrganization } from "../../Contexts/currentOrganizationContext";
@@ -13,23 +14,22 @@ import "./GrantCopy.css";
 
 export default function GrantCopy() {
   const [grant, setGrant] = useState(null);
-  const [fundingOrgs, setFundingOrgs] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const { organizationClient } = useCurrentOrganization();
   const buildOrganizationsLink = useBuildOrganizationsLink();
-  const { grantUuid } = useParams();
+  const { grantId } = useParams();
   const history = useHistory();
 
   const handleCancel = (event) => {
     event.preventDefault();
-    history.push(buildOrganizationsLink(`/grants/${grantUuid}`));
+    history.push(buildOrganizationsLink(`/grants/${grantId}`));
   };
 
   const handleSubmit = (newGrantFields) => {
-    copyGrant(organizationClient, grantUuid, newGrantFields)
+    copyGrant(organizationClient, grantId, newGrantFields)
       .then((copiedGrant) => {
         alert("Grant copied!");
-        history.push(buildOrganizationsLink(`/grants/${copiedGrant.uuid}`));
+        history.push(buildOrganizationsLink(`/grants/${copiedGrant.id}`));
       })
       .catch((error) => {
         console.error(error);
@@ -39,20 +39,19 @@ export default function GrantCopy() {
       });
   };
 
-  const loadFundingOrgs = useCallback(() => {
-    return getAllFundingOrgs(organizationClient).then(setFundingOrgs);
-  }, [organizationClient, setFundingOrgs]);
+  const { data: fundingOrgs } = useQuery("fundingOrgs", () =>
+    getAllFundingOrgs(organizationClient)
+  );
 
   useEffect(() => {
     if (!organizationClient) {
       return;
     }
 
-    Promise.all([
-      getGrant(organizationClient, grantUuid).then(setGrant),
-      loadFundingOrgs(),
-    ]).finally(() => setIsLoading(false));
-  }, [grantUuid, organizationClient, loadFundingOrgs]);
+    getGrant(organizationClient, grantId)
+      .then(setGrant)
+      .then(() => setIsLoading(false));
+  }, [grantId, organizationClient]);
 
   if (isLoading) {
     return "Loading...";
@@ -64,7 +63,6 @@ export default function GrantCopy() {
         <h1 className="grant-copy__header">Copy Grant</h1>
         <GrantForm
           grant={{ ...grant, title: `${grant.title} copy` }}
-          loadFundingOrgs={loadFundingOrgs}
           fundingOrgs={fundingOrgs}
           onSubmit={handleSubmit}
           onCancel={handleCancel}

--- a/src/Components/Grants/GrantForm.js
+++ b/src/Components/Grants/GrantForm.js
@@ -18,10 +18,10 @@ export default function GrantForm(props) {
   const [showingAddFundingOrgModal, setShowingAddFundingOrgModal] =
     useState(false);
 
-  const handleCloseFundingOrgModal = (fundingOrgUuid) => {
+  const handleCloseFundingOrgModal = (fundingOrgId) => {
     setShowingAddFundingOrgModal(false);
-    if (fundingOrgUuid) {
-      setGrantFields({ ...grantFields, fundingOrgUuid });
+    if (fundingOrgId) {
+      setGrantFields({ ...grantFields, fundingOrgId });
     }
   };
 
@@ -38,13 +38,13 @@ export default function GrantForm(props) {
           onClickAltLabel={() => setShowingAddFundingOrgModal(true)}
           labelText="Funding Organization"
           placeholder="Select a Funding Organization"
-          value={grantFields.fundingOrgUuid}
+          value={grantFields.fundingOrgId}
           options={props.fundingOrgs.map((fundingOrg) => ({
-            value: fundingOrg.uuid,
+            value: fundingOrg.id,
             label: fundingOrg.name,
           }))}
           onChange={(option) =>
-            setGrantFields({ ...grantFields, fundingOrgUuid: option.value })
+            setGrantFields({ ...grantFields, fundingOrgId: option.value })
           }
         />
         <TextBox

--- a/src/Components/Grants/GrantsIndex.js
+++ b/src/Components/Grants/GrantsIndex.js
@@ -47,38 +47,38 @@ export default function GrantsIndex() {
     try {
       switch (option.value) {
         case "REMOVE_FROM_SUBMITTED":
-          await updateGrant(organizationClient, grant.uuid, {
+          await updateGrant(organizationClient, grant.id, {
             submitted: false,
           });
           break;
         case "REMOVE_FROM_SUCCESSFUL":
-          await updateGrant(organizationClient, grant.uuid, {
+          await updateGrant(organizationClient, grant.id, {
             successful: false,
           });
           break;
         case "REMOVE_FROM_ARCHIVED":
-          await updateGrant(organizationClient, grant.uuid, {
+          await updateGrant(organizationClient, grant.id, {
             archived: false,
           });
           break;
         case "MARK_AS_SUCCESSFUL":
-          await updateGrant(organizationClient, grant.uuid, {
+          await updateGrant(organizationClient, grant.id, {
             successful: true,
           });
           break;
         case "MARK_AS_SUBMITTED":
-          await updateGrant(organizationClient, grant.uuid, {
+          await updateGrant(organizationClient, grant.id, {
             submitted: true,
           });
           break;
         case "MARK_AS_ARCHIVED":
-          await updateGrant(organizationClient, grant.uuid, {
+          await updateGrant(organizationClient, grant.id, {
             archived: true,
           });
           break;
         case "MAKE_A_COPY":
           return history.push(
-            buildOrganizationsLink(`/grants/${grant.uuid}/copy`)
+            buildOrganizationsLink(`/grants/${grant.id}/copy`)
           );
         default:
           throw new Error(`Unexpected option given ${option.value}!`);
@@ -106,7 +106,7 @@ export default function GrantsIndex() {
     {
       Header: "Title",
       accessor: (grant) => (
-        <CurrentOrganizationLink to={`/grants/${grant.uuid}`}>
+        <CurrentOrganizationLink to={`/grants/${grant.id}`}>
           {grant.title}
         </CurrentOrganizationLink>
       ),
@@ -213,7 +213,7 @@ export default function GrantsIndex() {
         />
         <Button
           as={Link}
-          to={`/organizations/${currentOrganization.uuid}/grants-new/`}
+          to={`/organizations/${currentOrganization.id}/grants-new/`}
         >
           Add New Grant
         </Button>

--- a/src/Components/Grants/GrantsNew.js
+++ b/src/Components/Grants/GrantsNew.js
@@ -19,7 +19,7 @@ export default function GrantsNew() {
   );
 
   const handleCancel = () => {
-    history.push(`/organizations/${currentOrganization.uuid}/grants`);
+    history.push(`/organizations/${currentOrganization.id}/grants`);
   };
 
   const { mutate: createGrant } = useMutation(
@@ -28,7 +28,7 @@ export default function GrantsNew() {
       onSuccess: (newGrant) => {
         alert("Grant created!");
         history.push(
-          `/organizations/${currentOrganization.uuid}/grants/${newGrant.uuid}`
+          `/organizations/${currentOrganization.id}/grants/${newGrant.id}`
         );
       },
     }
@@ -37,7 +37,7 @@ export default function GrantsNew() {
   function handleCreateGrant(newGrantFields) {
     createGrant({
       title: newGrantFields.title,
-      fundingOrgUuid: newGrantFields.fundingOrgUuid,
+      fundingOrgId: newGrantFields.fundingOrgId,
       rfpUrl: newGrantFields.rfpUrl,
       purpose: newGrantFields.purpose,
       deadline: newGrantFields.deadline,

--- a/src/Components/Grants/GrantsShow.js
+++ b/src/Components/Grants/GrantsShow.js
@@ -47,17 +47,17 @@ function countTotalSectionsWords(sections = []) {
 
 export default function GrantsShow() {
   const { currentOrganization, organizationClient } = useCurrentOrganization();
-  const { grantUuid } = useParams();
+  const { grantId } = useParams();
   const {
     data: grant,
     isError,
     isLoading,
     error,
   } = useQuery("getGrant", () =>
-    GrantsService.getGrant(organizationClient, grantUuid)
+    GrantsService.getGrant(organizationClient, grantId)
   );
-  const [newSectionUuid, setNewSectionUuid] = useState(null);
-  const [editingSectionUuid, setEditingSectionUuid] = useState(null);
+  const [newSectionId, setNewSectionId] = useState(null);
+  const [editingSectionId, setEditingSectionId] = useState(null);
   const totalWordCount = countTotalSectionsWords(grant?.sections);
 
   // const sensors = useSensors(
@@ -77,13 +77,13 @@ export default function GrantsShow() {
     (newSectionFields) =>
       SectionsService.createSection(
         organizationClient,
-        grantUuid,
+        grantId,
         newSectionFields
       ),
     {
       onSuccess: () => {
         alert("Section created!");
-        setNewSectionUuid(null);
+        setNewSectionId(null);
       },
     }
   );
@@ -92,14 +92,14 @@ export default function GrantsShow() {
     (newSectionFields) =>
       SectionsService.updateSection(
         organizationClient,
-        grantUuid,
-        newSectionFields.uuid,
+        grantId,
+        newSectionFields.id,
         newSectionFields
       ),
     {
       onSuccess: () => {
         alert("Section edited!");
-        setEditingSectionUuid(null);
+        setEditingSectionId(null);
       },
     }
   );
@@ -108,7 +108,7 @@ export default function GrantsShow() {
     createSection({
       title: newSectionFields.title,
       text: newSectionFields.html,
-      grantUuid: grantUuid,
+      grantId: grantId,
       sort_order: precedingSection ? precedingSection.sortOrder + 1 : 0,
       wordcount: countWords(newSectionFields.text),
     });
@@ -126,12 +126,12 @@ export default function GrantsShow() {
   // const handleDeleteSection = (sectionFields) => {
   //   // eslint-disable-next-line no-restricted-globals
   //   if (confirm(`Are you sure you want to delete this section?`)) {
-  //     updateGrantSection(organizationClient, grantUuid, sectionFields.uuid, {
+  //     updateGrantSection(organizationClient, grantId, sectionFields.id, {
   //       archived: true,
   //     })
   //       .then(() => {
   //         alert("Section deleted!");
-  //         setEditingSectionUuid(null);
+  //         setEditingSectionId(null);
   //       })
   //       .catch((error) => {
   //         console.error(error);
@@ -143,26 +143,26 @@ export default function GrantsShow() {
   // };
   // const handleReorderSection = (event) => {
   //   const { active, over } = event;
-  //   if (active.uuid !== over.uuid) {
+  //   if (active.id !== over.id) {
   //     setGrant((grant) => {
   //       const oldIndex = grant.sections.findIndex(
-  //         (section) => section.uuid === active.uuid
+  //         (section) => section.id === active.id
   //       );
   //       const newIndex = grant.sections.findIndex(
-  //         (section) => section.uuid === over.uuid
+  //         (section) => section.id === over.id
   //       );
   //       const reorderedSections = arrayMove(grant.sections, oldIndex, newIndex);
 
   //       return { ...grant, sections: reorderedSections };
   //     });
 
-  //     const sectionUuid = active.uuid;
+  //     const sectionId = active.id;
   //     const sortOrder = active.data.current.sortable.index;
 
-  //     reorderGrantSection(organizationClient, grant.uuid, sectionUuid, sortOrder)
+  //     reorderGrantSection(organizationClient, grant.id, sectionId, sortOrder)
   //       .then((response) => {
   //         console.log(
-  //           `Succesfully sorted section ${sectionUuid} to index ${sortOrder}!`,
+  //           `Succesfully sorted section ${sectionId} to index ${sortOrder}!`,
   //           response
   //         );
   //       })
@@ -180,11 +180,11 @@ export default function GrantsShow() {
     return <span>Error: {error.message}</span>;
   }
 
-  const noSectionsContent = newSectionUuid ? (
+  const noSectionsContent = newSectionId ? (
     <SectionForm
       onStoreSectionAsBoilerplate={setSectionToStoreAsBoilerplate}
       onSubmit={(newSectionFields) => handleCreateSection({ newSectionFields })}
-      onCancel={() => setNewSectionUuid(null)}
+      onCancel={() => setNewSectionId(null)}
     />
   ) : (
     <>
@@ -192,7 +192,7 @@ export default function GrantsShow() {
         Welcome to your grant! Get started by clicking the Add Section Button
         below.
       </p>
-      <Button onClick={() => setNewSectionUuid(1)} variant="text">
+      <Button onClick={() => setNewSectionId(1)} variant="text">
         <MdAddCircle />
         Add Section
       </Button>
@@ -214,9 +214,9 @@ export default function GrantsShow() {
           purposeText={grant.purpose}
           deadline={grant.deadline}
           totalWordCount={totalWordCount}
-          breadCrumbLink={`/organizations/${currentOrganization.uuid}/grants/`}
-          copyLink={`/grants/${grant.uuid}/copy/`}
-          editLink={`/grants/${grant.uuid}/edit/`}
+          breadCrumbLink={`/organizations/${currentOrganization.id}/grants/`}
+          copyLink={`/grants/${grant.id}/copy/`}
+          editLink={`/grants/${grant.id}/edit/`}
         />
         <Container
           className="grants-show__sections-container"
@@ -235,23 +235,23 @@ export default function GrantsShow() {
           {grant.sections.length ? (
             <ol className="grants-show__section-list">
               {grant.sections.map((section) => (
-                <SortableElement key={section.uuid} id={section.uuid}>
-                  {editingSectionUuid === section.uuid ? (
+                <SortableElement key={section.id} id={section.id}>
+                  {editingSectionId === section.id ? (
                     <SectionForm
                       onStoreSectionAsBoilerplate={
                         setSectionToStoreAsBoilerplate
                       }
                       onSubmit={handleEditSection}
-                      onCancel={() => setEditingSectionUuid(null)}
+                      onCancel={() => setEditingSectionId(null)}
                       section={section}
                     />
                   ) : (
                     <SectionsShow
                       section={section}
-                      onClickEdit={setEditingSectionUuid}
+                      onClickEdit={setEditingSectionId}
                     />
                   )}
-                  {newSectionUuid === section.uuid && (
+                  {newSectionId === section.id && (
                     <SectionForm
                       onStoreSectionAsBoilerplate={
                         setSectionToStoreAsBoilerplate
@@ -262,11 +262,11 @@ export default function GrantsShow() {
                           precedingSection: section,
                         })
                       }
-                      onCancel={() => setNewSectionUuid(null)}
+                      onCancel={() => setNewSectionId(null)}
                     />
                   )}
                   <Button
-                    onClick={() => setNewSectionUuid(section.uuid)}
+                    onClick={() => setNewSectionId(section.id)}
                     variant="text"
                   >
                     <MdAddCircle />

--- a/src/Components/Helpers/CurrentOrganizationLink.js
+++ b/src/Components/Helpers/CurrentOrganizationLink.js
@@ -9,7 +9,7 @@ export default function CurrentOrganizationLink(props) {
   return (
     <Component
       {...restProps}
-      to={`/organizations/${currentOrganization.uuid}${to}`}
+      to={`/organizations/${currentOrganization.id}${to}`}
     />
   );
 }

--- a/src/Components/Layouts/OrganizationLayout/OrganizationLayout.js
+++ b/src/Components/Layouts/OrganizationLayout/OrganizationLayout.js
@@ -13,17 +13,17 @@ export default function OrganizationLayout(props) {
     isLoadingOrganization,
     fetchCurrentOrganization,
   } = useCurrentOrganization();
-  const { organizationUuid } = useParams();
+  const { organizationId } = useParams();
 
   useEffect(() => {
     if (!currentOrganization && !isLoadingOrganization) {
-      fetchCurrentOrganization(organizationUuid);
+      fetchCurrentOrganization(organizationId);
     }
   }, [
     currentOrganization,
     isLoadingOrganization,
     fetchCurrentOrganization,
-    organizationUuid,
+    organizationId,
   ]);
 
   if (!currentOrganization) {

--- a/src/Components/Layouts/OrganizationLayout/OrganizationLayout.stories.js
+++ b/src/Components/Layouts/OrganizationLayout/OrganizationLayout.stories.js
@@ -35,7 +35,7 @@ const ContextWrapper = () => {
       type: "SET_CURRENT_ORGANIZATION",
       payload: {
         currentOrganization: {
-          uuid: "06a7796b-f5f7-4261-9830-3892fb604f24",
+          id: "06a7796b-f5f7-4261-9830-3892fb604f24",
           name: "Baklava Foundation",
         },
       },
@@ -49,10 +49,8 @@ const ContextWrapper = () => {
   return (
     <Component>
       <Switch>
-        <Route path="/organizations/:organizationUuid/dashboard">
-          Dashboard
-        </Route>
-        <Route path="/organizations/:organizationUuid/reports">Reports</Route>
+        <Route path="/organizations/:organizationId/dashboard">Dashboard</Route>
+        <Route path="/organizations/:organizationId/reports">Reports</Route>
         <Route path="/">
           <Redirect to="/organizations/2/dashboard" />
         </Route>

--- a/src/Components/Organizations/OrgSelect.js
+++ b/src/Components/Organizations/OrgSelect.js
@@ -9,7 +9,7 @@ import Button from "../design/Button/Button";
 export default function OrgSelect() {
   const { user } = useCurrentUser();
   const { organizations } = useCurrentOrganization();
-  const [currentOrganizationUuid, setCurrentOrganizationUuid] = useState();
+  const [currentOrganizationId, setCurrentOrganizationId] = useState();
 
   return (
     <Container as="section" className="org-select">
@@ -20,20 +20,20 @@ export default function OrgSelect() {
       </p>
       <form>
         <Dropdown
-          onChange={(option) => setCurrentOrganizationUuid(option.value)}
+          onChange={(option) => setCurrentOrganizationId(option.value)}
           labelText="Organization"
           placeholder="Select Organization"
-          value={currentOrganizationUuid}
+          value={currentOrganizationId}
           options={organizations.map((organization) => ({
-            value: organization.uuid,
+            value: organization.id,
             label: organization.name,
           }))}
           required
         />
-        {currentOrganizationUuid && (
+        {currentOrganizationId && (
           <Button
             as={Link}
-            to={`/organizations/${currentOrganizationUuid}/dashboard`}
+            to={`/organizations/${currentOrganizationId}/dashboard`}
           >
             Go to Dashboard
           </Button>

--- a/src/Components/ReportSections/ReportSectionsNew.js
+++ b/src/Components/ReportSections/ReportSectionsNew.js
@@ -22,7 +22,7 @@ export default function ReportSectionsNew(props) {
   const { currentOrganization, organizationClient } = useCurrentOrganization();
 
   useEffect(() => {
-    if (currentOrganization.uuid) {
+    if (currentOrganization.id) {
       getAllBoilerplates(organizationClient)
         .then((boilerplates) => {
           setBoilerplates(boilerplates);
@@ -31,7 +31,7 @@ export default function ReportSectionsNew(props) {
           console.error(error);
         });
     }
-  }, [currentOrganization.uuid, organizationClient]);
+  }, [currentOrganization.id, organizationClient]);
 
   const clearForm = () => {
     setQuillText("");
@@ -45,7 +45,7 @@ export default function ReportSectionsNew(props) {
   const handleSubmit = (event) => {
     event.preventDefault();
     const newReportSection = {
-      reportUuid: props.reportUuid,
+      reportId: props.reportId,
       title: title,
       text: quillText,
       sort_order: props.sort_number + 1,
@@ -53,8 +53,8 @@ export default function ReportSectionsNew(props) {
     };
     createReportSection(
       organizationClient,
-      props.grantUuid,
-      props.reportUuid,
+      props.grantId,
+      props.reportId,
       newReportSection
     )
       .then((reportSection) => {
@@ -102,7 +102,7 @@ export default function ReportSectionsNew(props) {
       <div>
         {suggestions.map((boilerplate) => (
           <li
-            key={boilerplate.uuid}
+            key={boilerplate.id}
             onClick={() => suggestionSelected(boilerplate)}
           >
             {boilerplate.title}, {boilerplate.wordcount} words
@@ -156,7 +156,7 @@ export default function ReportSectionsNew(props) {
               {boilerplates.map((boilerplate) => {
                 return (
                   <option
-                    key={boilerplate.uuid}
+                    key={boilerplate.id}
                     value={boilerplate.text}
                     onChange={(event) =>
                       setCurrentBoilerplate(event.target.value)

--- a/src/Components/ReportSections/ReportSectionsShow.js
+++ b/src/Components/ReportSections/ReportSectionsShow.js
@@ -18,7 +18,7 @@ export default function ReportSectionsShow(props) {
   const [_text, setText] = useState("");
   const [sortOrder, setSortOrder] = useState("");
   const [_wordcount, setWordcount] = useState("");
-  const [_reportUuid, setReportUuid] = useState("");
+  const [_reportId, setReportId] = useState("");
   const [isHidden, setIsHidden] = useState(true);
   const [loading, setLoading] = useState(true);
   const [_newQuillText, setNewQuillText] = useState("");
@@ -31,24 +31,19 @@ export default function ReportSectionsShow(props) {
   const handleClose = () => setShow(false);
 
   useEffect(() => {
-    if (currentOrganization.uuid) {
-      const grantUuid = props.grantUuid;
-      const reportUuid = props.reportUuid;
-      const reportSectionUuid = props.reportSectionUuid;
-      getReportSection(
-        organizationClient,
-        grantUuid,
-        reportUuid,
-        reportSectionUuid
-      )
+    if (currentOrganization.id) {
+      const grantId = props.grantId;
+      const reportId = props.reportId;
+      const reportSectionId = props.reportSectionId;
+      getReportSection(organizationClient, grantId, reportId, reportSectionId)
         .then((reportSection) => {
-          setId(reportSection.uuid);
+          setId(reportSection.id);
           setTitle(reportSection.title);
           setText(reportSection.text);
           setQuillText(reportSection.text);
           setSortOrder(reportSection.sort_order);
           setWordcount(reportSection.wordcount);
-          setReportUuid(reportSection.reportUuid);
+          setReportId(reportSection.reportId);
           setLoading(false);
           setNewTitle(reportSection.title);
           setNewQuillText(reportSection.text);
@@ -59,11 +54,11 @@ export default function ReportSectionsShow(props) {
         });
     }
   }, [
-    currentOrganization.uuid,
+    currentOrganization.id,
     organizationClient,
-    props.grantUuid,
-    props.reportUuid,
-    props.reportSectionUuid,
+    props.grantId,
+    props.reportId,
+    props.reportSectionId,
   ]);
 
   const toggleHidden = () => {
@@ -71,20 +66,20 @@ export default function ReportSectionsShow(props) {
   };
 
   const handleSubmit = ({ newTitle, newQuillText, newSortOrder }) => {
-    const grantUuid = props.grantUuid;
-    const reportUuid = props.reportUuid;
-    const reportSectionUuid = props.reportSectionUuid;
+    const grantId = props.grantId;
+    const reportId = props.reportId;
+    const reportSectionId = props.reportSectionId;
     updateReportSection(
       organizationClient,
-      grantUuid,
-      reportUuid,
-      reportSectionUuid,
+      grantId,
+      reportId,
+      reportSectionId,
       {
         title: newTitle,
         text: newQuillText,
         sort_order: newSortOrder,
         wordcount: countWords(newQuillText),
-        reportUuid: reportUuid,
+        reportId: reportId,
       },
       { headers: { Authorization: `Bearer ${localStorage.token}` } }
     )

--- a/src/Components/ReportSections/ReportSectionsUpdateFinal.js
+++ b/src/Components/ReportSections/ReportSectionsUpdateFinal.js
@@ -17,7 +17,7 @@ export default function ReportSectionsUpdateFinal(props) {
   const [title, setTitle] = useState("");
   const [isHidden, setIsHidden] = useState(true);
   const [_wordcount, setWordcount] = useState("");
-  const [_reportUuid, setReportUuid] = useState("");
+  const [_reportId, setReportId] = useState("");
   const [_sort_order, setSortOrder] = useState("");
   const [loading, setLoading] = useState(true);
 
@@ -28,38 +28,38 @@ export default function ReportSectionsUpdateFinal(props) {
   const { currentOrganization, organizationClient } = useCurrentOrganization();
 
   useEffect(() => {
-    if (currentOrganization.uuid) {
+    if (currentOrganization.id) {
       getGrantSection(
         organizationClient,
-        props.grantUuid,
-        props.reportUuid,
-        props.reportSectionUuid
+        props.grantId,
+        props.reportId,
+        props.reportSectionId
       )
         .then((reportSection) => {
           setTitle(reportSection.title);
           setQuillText(reportSection.text);
           setWordcount(reportSection.wordcount);
           setSortOrder(reportSection.sort_order);
-          setReportUuid(reportSection.reportUuid);
+          setReportId(reportSection.reportId);
           setLoading(false);
         })
         .catch((error) => console.error(error));
     }
   }, [
-    currentOrganization.uuid,
+    currentOrganization.id,
     organizationClient,
-    props.grantUuid,
-    props.reportUuid,
-    props.reportSectionUuid,
+    props.grantId,
+    props.reportId,
+    props.reportSectionId,
   ]);
 
   const handleSubmit = (event) => {
     event.preventDefault();
     updateReportSection(
       organizationClient,
-      props.grantUuid,
-      props.reportUuid,
-      props.reportSectionUuid,
+      props.grantId,
+      props.reportId,
+      props.reportSectionId,
       {
         title: title,
         text: quillText,
@@ -80,14 +80,14 @@ export default function ReportSectionsUpdateFinal(props) {
   };
 
   const handleReportSectionDelete = () => {
-    const grantUuid = props.match.params.grantUuid;
-    const reportUuid = props.match.params.reportUuid;
-    const reportSectionUuid = props.match.params.reportSectionUuid;
+    const grantId = props.match.params.grantId;
+    const reportId = props.match.params.reportId;
+    const reportSectionId = props.match.params.reportSectionId;
     deleteGrantSection(
       organizationClient,
-      grantUuid,
-      reportUuid,
-      reportSectionUuid
+      grantId,
+      reportId,
+      reportSectionId
     ).catch((error) => {
       console.error(error);
     });

--- a/src/Components/Reports/ReportsNew.js
+++ b/src/Components/Reports/ReportsNew.js
@@ -24,12 +24,12 @@ export default function ReportsNew(props) {
   const handleSubmit = (event) => {
     event.preventDefault();
     const newReport = {
-      grantUuid: props.grantUuid,
+      grantId: props.grantId,
       title: title,
       deadline: deadline,
       submitted: submitted,
     };
-    createGrantReport(organizationClient, props.grantUuid, newReport)
+    createGrantReport(organizationClient, props.grantId, newReport)
       .then((report) => {
         if (report) {
           toggleHidden();

--- a/src/Components/Reports/ReportsShow.js
+++ b/src/Components/Reports/ReportsShow.js
@@ -25,9 +25,8 @@ export default function ReportsShow() {
   const [report, setReport] = useState(null);
   const [loading, setLoading] = useState(true);
   const [errors, setErrors] = useState([]);
-  const [newReportSectionUuid, setNewReportSectionUuid] = useState(null);
-  const [editingReportSectionUuid, setEditingReportSectionUuid] =
-    useState(null);
+  const [newReportSectionId, setNewReportSectionId] = useState(null);
+  const [editingReportSectionId, setEditingReportSectionId] = useState(null);
   const { currentOrganization, organizationClient } = useCurrentOrganization();
   const totalWordCount = useMemo(
     () =>
@@ -38,7 +37,7 @@ export default function ReportsShow() {
     [report.reportSections]
   );
 
-  const { grantUuid, reportUuid } = useParams();
+  const { grantId, reportId } = useParams();
   // const { isOpen } = useContext(PasteBoilerplateContentPopoutContext);
 
   const [sectionToStoreAsBoilerplate, setSectionToStoreAsBoilerplate] =
@@ -48,32 +47,28 @@ export default function ReportsShow() {
     if (!organizationClient) {
       return;
     }
-    GrantReportsService.getGrantReport(
-      organizationClient,
-      grantUuid,
-      reportUuid
-    )
+    GrantReportsService.getGrantReport(organizationClient, grantId, reportId)
       .then((report) => setReport(report))
       .catch((error) => setErrors([error]))
       .finally(() => setLoading(false));
-  }, [organizationClient, grantUuid, reportUuid]);
+  }, [organizationClient, grantId, reportId]);
 
   const handleCreateReportSection = ({
     newReportSectionFields,
     precedingReportSection,
   }) => {
-    createReportSection(organizationClient, grantUuid, reportUuid, {
+    createReportSection(organizationClient, grantId, reportId, {
       title: newReportSectionFields.title,
       text: newReportSectionFields.html,
-      grantUuid,
-      reportUuid,
+      grantId,
+      reportId,
       sort_order: precedingReportSection
         ? precedingReportSection.sortOrder + 1
         : 0,
       wordcount: countWords(newReportSectionFields.text),
     }).then(() => {
       alert("Report Section created!");
-      setNewReportSectionUuid(null);
+      setNewReportSectionId(null);
       return getGrantReport();
     });
   };
@@ -81,8 +76,8 @@ export default function ReportsShow() {
   const handleEditReportSection = (newReportSectionFields) => {
     updateReportSection(
       organizationClient,
-      grantUuid,
-      newReportSectionFields.uuid,
+      grantId,
+      newReportSectionFields.id,
       {
         title: newReportSectionFields.title,
         text: newReportSectionFields.html,
@@ -90,7 +85,7 @@ export default function ReportsShow() {
       }
     ).then(() => {
       alert("Report Section edited!");
-      setEditingReportSectionUuid(null);
+      setEditingReportSectionId(null);
       return getGrantReport();
     });
   };
@@ -106,13 +101,13 @@ export default function ReportsShow() {
     return <h1>Loading....</h1>;
   }
 
-  const noReportSectionsContent = newReportSectionUuid ? (
+  const noReportSectionsContent = newReportSectionId ? (
     <SectionForm
       onStoreSectionAsBoilerplate={setSectionToStoreAsBoilerplate}
       onSubmit={(newReportSectionFields) =>
         handleCreateReportSection({ newReportSectionFields })
       }
-      onCancel={() => setNewReportSectionUuid(null)}
+      onCancel={() => setNewReportSectionId(null)}
     />
   ) : (
     <>
@@ -120,7 +115,7 @@ export default function ReportsShow() {
         Welcome to your grant! Get started by clicking the Add Section Button
         below.
       </p>
-      <Button onClick={() => setNewReportSectionUuid(1)} variant="text">
+      <Button onClick={() => setNewReportSectionId(1)} variant="text">
         <MdAddCircle />
         Add Section
       </Button>
@@ -145,9 +140,9 @@ export default function ReportsShow() {
           purposeText={"purpose"}
           deadline={report.deadline}
           totalWordCount={totalWordCount}
-          breadCrumbLink={`/organizations/${currentOrganization.uuid}/reports/`}
-          copyLink={`/reports/${report.uuid}/copy/`}
-          editLink={`/reports/${report.uuid}/edit/`}
+          breadCrumbLink={`/organizations/${currentOrganization.id}/reports/`}
+          copyLink={`/reports/${report.id}/copy/`}
+          editLink={`/reports/${report.id}/edit/`}
         />
         <Container
           className="reports-show__sections-container"
@@ -157,26 +152,23 @@ export default function ReportsShow() {
           {report.reportSections.length ? (
             <ol className="reports-show__section-list">
               {report.reportSections.map((reportSection) => (
-                <SortableElement
-                  key={reportSection.uuid}
-                  id={reportSection.uuid}
-                >
-                  {editingReportSectionUuid === reportSection.uuid ? (
+                <SortableElement key={reportSection.id} id={reportSection.id}>
+                  {editingReportSectionId === reportSection.id ? (
                     <SectionForm
                       onStoreSectionAsBoilerplate={
                         setSectionToStoreAsBoilerplate
                       }
                       onSubmit={handleEditReportSection}
-                      onCancel={() => setEditingReportSectionUuid(null)}
+                      onCancel={() => setEditingReportSectionId(null)}
                       section={reportSection}
                     />
                   ) : (
                     <SectionsShow
                       section={reportSection}
-                      onClickEdit={setEditingReportSectionUuid}
+                      onClickEdit={setEditingReportSectionId}
                     />
                   )}
-                  {newReportSectionUuid === reportSection.uuid && (
+                  {newReportSectionId === reportSection.id && (
                     <SectionForm
                       onStoreSectionAsBoilerplate={
                         setSectionToStoreAsBoilerplate
@@ -187,11 +179,11 @@ export default function ReportsShow() {
                           precedingReportSection: reportSection,
                         })
                       }
-                      onCancel={() => setNewReportSectionUuid(null)}
+                      onCancel={() => setNewReportSectionId(null)}
                     />
                   )}
                   <Button
-                    onClick={() => setNewReportSectionUuid(reportSection.uuid)}
+                    onClick={() => setNewReportSectionId(reportSection.id)}
                     variant="text"
                   >
                     <MdAddCircle />

--- a/src/Components/Sections/SectionsNew.js
+++ b/src/Components/Sections/SectionsNew.js
@@ -25,7 +25,7 @@ export default function SectionsNew(props) {
   const { currentOrganization, organizationClient } = useCurrentOrganization();
 
   useEffect(() => {
-    if (currentOrganization.uuid) {
+    if (currentOrganization.id) {
       getAllBoilerplates(organizationClient)
         .then((boilerplates) => {
           setBoilerplates(boilerplates);
@@ -34,7 +34,7 @@ export default function SectionsNew(props) {
           console.error(error);
         });
     }
-  }, [currentOrganization.uuid, organizationClient]);
+  }, [currentOrganization.id, organizationClient]);
 
   const handleSearchParamSelect = (event) => {
     setFilterParam(event.target.value);
@@ -85,13 +85,13 @@ export default function SectionsNew(props) {
   const handleSubmit = (event) => {
     event.preventDefault();
     const newSection = {
-      grantUuid: props.grantUuid,
+      grantId: props.grantId,
       title: title,
       text: quillText,
       sort_order: props.sort_number + 1,
       wordcount: countWords(quillText),
     };
-    createGrantSection(organizationClient, props.grantUuid, newSection)
+    createGrantSection(organizationClient, props.grantId, newSection)
       .then((section) => {
         if (section) {
           props.addNewSections(section);
@@ -120,7 +120,7 @@ export default function SectionsNew(props) {
       <div>
         {suggestions.map((boilerplate) => (
           <li
-            key={boilerplate.uuid}
+            key={boilerplate.id}
             onClick={() => suggestionSelected(boilerplate)}
           >
             {boilerplate.title}, {boilerplate.wordcount} words
@@ -210,7 +210,7 @@ export default function SectionsNew(props) {
                   {boilerplates.map((boilerplate) => {
                     return (
                       <option
-                        key={boilerplate.uuid}
+                        key={boilerplate.id}
                         value={boilerplate.text}
                         onChange={(event) =>
                           setCurrentBoilerplate(event.target.value)

--- a/src/Components/Sections/SectionsShow.js
+++ b/src/Components/Sections/SectionsShow.js
@@ -12,7 +12,7 @@ export default function SectionsShow(props) {
       <div className="section__header">
         <h2 className="section__title heading-4">
           {section.title}{" "}
-          <Button variant="none" onClick={() => onClickEdit(section.uuid)}>
+          <Button variant="none" onClick={() => onClickEdit(section.id)}>
             <MdEditNote className="section__edit-icon" />
           </Button>
         </h2>

--- a/src/Components/Sections/StoreSectionAsBoilerplate.js
+++ b/src/Components/Sections/StoreSectionAsBoilerplate.js
@@ -15,7 +15,7 @@ export default function StoreSectionAsBoilerplate(props) {
   const [newBoilerplateFields, setNewBoilerplateFields] = useState({
     title: props.section.title,
     text: props.section.text,
-    categoryUuid: "",
+    categoryId: "",
     wordcount: "",
   });
   const { organizationClient } = useCurrentOrganization();
@@ -66,15 +66,15 @@ export default function StoreSectionAsBoilerplate(props) {
       <Dropdown
         labelText="Category"
         placeholder="Select Category"
-        value={newBoilerplateFields.categoryUuid}
+        value={newBoilerplateFields.categoryId}
         onChange={(option) => {
           setNewBoilerplateFields({
             ...newBoilerplateFields,
-            categoryUuid: option.value,
+            categoryId: option.value,
           });
         }}
         options={categories.map((category) => ({
-          value: category.uuid,
+          value: category.id,
           label: category.name,
         }))}
       />

--- a/src/Components/design/Sidebar/Sidebar.stories.js
+++ b/src/Components/design/Sidebar/Sidebar.stories.js
@@ -13,21 +13,21 @@ export const Sidebar = (props) => (
       <Component {...props} />
       <div style={{ backgroundColor: "#f5f7f9", padding: "20px", flex: "1" }}>
         <Switch>
-          <Route path="/organizations/:organizationUuid/dashboard">
+          <Route path="/organizations/:organizationId/dashboard">
             Dashboard
           </Route>
-          <Route path="/organizations/:organizationUuid/reports">Reports</Route>
-          <Route path="/organizations/:organizationUuid/grants">Grants</Route>
-          <Route path="/organizations/:organizationUuid/boilerplates">
+          <Route path="/organizations/:organizationId/reports">Reports</Route>
+          <Route path="/organizations/:organizationId/grants">Grants</Route>
+          <Route path="/organizations/:organizationId/boilerplates">
             Boilerplates
           </Route>
-          <Route path="/organizations/:organizationUuid/funding_orgs">
+          <Route path="/organizations/:organizationId/funding_orgs">
             Funding Organizations
           </Route>
-          <Route path="/organizations/:organizationUuid/categories">
+          <Route path="/organizations/:organizationId/categories">
             Categories
           </Route>
-          <Route path="/organizations/:organizationUuid/users">Users</Route>
+          <Route path="/organizations/:organizationId/users">Users</Route>
           <Route path="/">
             <Redirect to="/organizations/77c48824-3904-449a-9966-e0d8af2f9f64/dashboard" />
           </Route>

--- a/src/Contexts/currentOrganizationContext.js
+++ b/src/Contexts/currentOrganizationContext.js
@@ -30,19 +30,19 @@ export const CurrentOrganizationProvider = ({ children }) => {
     setOrganizations(organizations);
   }, [authenticatedApiClient]);
 
-  const fetchCurrentOrganization = async (organizationUuid) => {
+  const fetchCurrentOrganization = async (organizationId) => {
     try {
       setIsLoadingOrganization(true);
 
       const organizationClient = axios.create({
         ...authenticatedApiClient.defaults,
-        baseURL: `${apiClient.defaults.baseURL}/organizations/${organizationUuid}`,
+        baseURL: `${apiClient.defaults.baseURL}/organizations/${organizationId}`,
       });
       setOrganizationClient(() => organizationClient);
 
       const organization = await getOrganization(
         authenticatedApiClient,
-        organizationUuid
+        organizationId
       );
       setCurrentOrganization(organization);
     } finally {

--- a/src/Hooks/useBuildOrganizationsLink.js
+++ b/src/Hooks/useBuildOrganizationsLink.js
@@ -4,6 +4,6 @@ export default function useBuildOrganizationsLink() {
   const { currentOrganization } = useCurrentOrganization();
 
   return (path) => {
-    return `/organizations/${currentOrganization.uuid}${path}`;
+    return `/organizations/${currentOrganization.id}${path}`;
   };
 }

--- a/src/Services/Auth/LoginService.js
+++ b/src/Services/Auth/LoginService.js
@@ -5,7 +5,7 @@ export const mapUser = (apiUser) => ({
   createdAt: new Date(apiUser.created_at),
   email: apiUser.email,
   firstName: apiUser.first_name,
-  uuid: apiUser.uuid,
+  id: apiUser.id,
   lastName: apiUser.last_name,
   updatedAt: new Date(apiUser.updated_at),
 });

--- a/src/Services/OrganizationService.js
+++ b/src/Services/OrganizationService.js
@@ -2,7 +2,7 @@ import { mapUser } from "./Auth/LoginService";
 
 const mapOrganization = (apiOrganization) => ({
   createdAt: new Date(apiOrganization.created_at),
-  uuid: apiOrganization.uuid,
+  id: apiOrganization.id,
   name: apiOrganization.name,
   updatedAt: new Date(apiOrganization.updated_at),
 });
@@ -13,9 +13,9 @@ export const getUserOrganizations = (apiClient) => {
     .then((response) => response.data.map(mapOrganization));
 };
 
-export const getOrganization = (apiClient, organizationUuid) => {
+export const getOrganization = (apiClient, organizationId) => {
   return apiClient
-    .get(`/organizations/${organizationUuid}`)
+    .get(`/organizations/${organizationId}`)
     .then((response) => mapOrganization(response.data));
 };
 

--- a/src/Services/Organizations/BoilerplatesService.js
+++ b/src/Services/Organizations/BoilerplatesService.js
@@ -1,10 +1,10 @@
 const mapBoilerplate = (apiBoilerplate) => ({
   archived: apiBoilerplate.archived,
   createdAt: new Date(apiBoilerplate.created_at),
-  categoryUuid: apiBoilerplate.category_uuid,
+  categoryId: apiBoilerplate.category_id,
   categoryName: apiBoilerplate.category_name,
-  uuid: apiBoilerplate.uuid,
-  organizationUuid: apiBoilerplate.organization_uuid,
+  id: apiBoilerplate.id,
+  organizationId: apiBoilerplate.organization_id,
   title: apiBoilerplate.title,
   text: apiBoilerplate.text,
   wordcount: apiBoilerplate.wordcount,
@@ -13,14 +13,14 @@ const mapBoilerplate = (apiBoilerplate) => ({
 
 const mapBoilerplateToApiBoilerplate = (boilerplate) => ({
   ...boilerplate,
-  category_id: boilerplate.categoryUuid,
-  organization_id: boilerplate.organizationUuid,
+  category_id: boilerplate.categoryId,
+  organization_id: boilerplate.organizationId,
 });
 
 // getBoilerplate
-export const getBoilerplate = (organizationClient, boilerplateUuid) => {
+export const getBoilerplate = (organizationClient, boilerplateId) => {
   return organizationClient
-    .get(`/boilerplates/${boilerplateUuid}`)
+    .get(`/boilerplates/${boilerplateId}`)
     .then((response) => mapBoilerplate(response.data));
 };
 
@@ -34,9 +34,9 @@ export const getAllBoilerplates = (organizationClient) => {
 
 // deleteBoilerplate
 
-export const deleteBoilerplate = (organizationClient, boilerplateUuid) => {
+export const deleteBoilerplate = (organizationClient, boilerplateId) => {
   return organizationClient
-    .delete(`/boilerplates/${boilerplateUuid}`)
+    .delete(`/boilerplates/${boilerplateId}`)
     .then((response) => response.data);
 };
 
@@ -52,12 +52,12 @@ export const createBoilerplate = (organizationClient, newBoilerplate) => {
 
 export const updateBoilerplate = (
   organizationClient,
-  boilerplateUuid,
+  boilerplateId,
   fieldsToUpdate
 ) => {
   return organizationClient
     .patch(
-      `/boilerplates/${boilerplateUuid}`,
+      `/boilerplates/${boilerplateId}`,
       mapBoilerplateToApiBoilerplate(fieldsToUpdate)
     )
     .then((response) => response.data);
@@ -68,12 +68,12 @@ export const updateBoilerplate = (
 
 // export const copyBoilerplate = (
 //   organizationClient,
-//   boilerplateUuid,
+//   boilerplateId,
 //   copyBoilerplateFields
 // ) => {
 //   return organizationClient
 //     .post(
-//       `/boilerplates/${boilerplateUuid}/copy`,
+//       `/boilerplates/${boilerplateId}/copy`,
 //       mapBoilerplateToApiBoilerplate(copyBoilerplateFields)
 //     )
 //     .then((response) => response.data);

--- a/src/Services/Organizations/CategoriesService.js
+++ b/src/Services/Organizations/CategoriesService.js
@@ -3,19 +3,19 @@ const mapCategory = (apiCategory) => ({
   updatedAt: new Date(apiCategory.updated_at),
   name: apiCategory.name,
   archived: apiCategory.archived,
-  uuid: apiCategory.uuid,
-  organizationUuid: apiCategory.organization_uuid,
+  id: apiCategory.id,
+  organizationId: apiCategory.organization_id,
 });
 
 const mapCategoryToApiCategory = (category) => ({
   ...category,
-  organization_id: category.organizationUuid,
+  organization_id: category.organizationId,
 });
 
 // getCategory
-export const getCategory = (organizationClient, categoryUuid) => {
+export const getCategory = (organizationClient, categoryId) => {
   return organizationClient
-    .get(`/categories/${categoryUuid}`)
+    .get(`/categories/${categoryId}`)
     .then((response) => response.data);
 };
 
@@ -29,9 +29,9 @@ export const getAllCategories = (organizationClient) => {
 
 // deleteCategory
 
-export const deleteCategory = (organizationClient, categoryUuid) => {
+export const deleteCategory = (organizationClient, categoryId) => {
   return organizationClient
-    .delete(`/categories/${categoryUuid}`)
+    .delete(`/categories/${categoryId}`)
     .then((response) => response.data);
 };
 
@@ -47,12 +47,12 @@ export const createCategory = (organizationClient, newCategory) => {
 
 export const updateCategory = (
   organizationClient,
-  categoryUuid,
+  categoryId,
   fieldsToUpdate
 ) => {
   return organizationClient
     .patch(
-      `/categories/${categoryUuid}`,
+      `/categories/${categoryId}`,
       mapCategoryToApiCategory(fieldsToUpdate)
     )
     .then((response) => response.data);

--- a/src/Services/Organizations/FundingOrgsService.js
+++ b/src/Services/Organizations/FundingOrgsService.js
@@ -4,19 +4,19 @@ const mapFundingOrg = (apiFundingOrg) => ({
   name: apiFundingOrg.name,
   website: apiFundingOrg.website,
   archived: apiFundingOrg.archived,
-  uuid: apiFundingOrg.uuid,
-  organizationUuid: apiFundingOrg.organization_uuid,
+  id: apiFundingOrg.id,
+  organizationId: apiFundingOrg.organization_id,
 });
 
 const mapFundingOrgToApiFundingOrg = (fundingOrg) => ({
   ...fundingOrg,
-  organization_id: fundingOrg.organizationUuid,
+  organization_id: fundingOrg.organizationId,
 });
 
 // getFundingOrg
-export const getFundingOrg = (organizationClient, fundingOrgUuid) => {
+export const getFundingOrg = (organizationClient, fundingOrgId) => {
   return organizationClient
-    .get(`/funding_orgs/${fundingOrgUuid}`)
+    .get(`/funding_orgs/${fundingOrgId}`)
     .then((response) => response.data);
 };
 
@@ -30,9 +30,9 @@ export const getAllFundingOrgs = (organizationClient) => {
 
 // deleteFundingOrg
 
-export const deleteFundingOrg = (organizationClient, fundingOrgUuid) => {
+export const deleteFundingOrg = (organizationClient, fundingOrgId) => {
   return organizationClient
-    .delete(`/funding_orgs/${fundingOrgUuid}`)
+    .delete(`/funding_orgs/${fundingOrgId}`)
     .then((response) => response.data);
 };
 
@@ -48,12 +48,12 @@ export const createFundingOrg = (organizationClient, newFundingOrg) => {
 
 export const updateFundingOrg = (
   organizationClient,
-  fundingOrgUuid,
+  fundingOrgId,
   fieldsToUpdate
 ) => {
   return organizationClient
     .patch(
-      `/funding_orgs/${fundingOrgUuid}`,
+      `/funding_orgs/${fundingOrgId}`,
       mapFundingOrgToApiFundingOrg(fieldsToUpdate)
     )
     .then((response) => response.data);

--- a/src/Services/Organizations/Grants/GrantReportsService.js
+++ b/src/Services/Organizations/Grants/GrantReportsService.js
@@ -4,8 +4,8 @@ const mapGrantReport = (apiGrantReport) => ({
   archived: apiGrantReport.archived,
   createdAt: new Date(apiGrantReport.created_at),
   deadline: new Date(apiGrantReport.deadline),
-  grantUuid: apiGrantReport.grant_id,
-  uuid: apiGrantReport.uuid,
+  grantId: apiGrantReport.grant_id,
+  id: apiGrantReport.id,
   title: apiGrantReport.title,
   updatedAt: new Date(apiGrantReport.updated_at),
   reportSections: apiGrantReport.report_sections
@@ -15,33 +15,29 @@ const mapGrantReport = (apiGrantReport) => ({
 
 const mapGrantReportToApiGrantReport = (grantReport) => ({
   ...grantReport,
-  grant_id: grantReport.grantUuid,
+  grant_id: grantReport.grantId,
 });
 
 // getGrantReport
-export const getGrantReport = (organizationClient, grantUuid, reportUuid) => {
+export const getGrantReport = (organizationClient, grantId, reportId) => {
   return organizationClient
-    .get(`/grants/${grantUuid}/reports/${reportUuid}`)
+    .get(`/grants/${grantId}/reports/${reportId}`)
     .then((response) => mapGrantReport(response.data));
 };
 
 // listGrantReports
 
-export const getAllGrantReports = (organizationClient, grantUuid) => {
+export const getAllGrantReports = (organizationClient, grantId) => {
   return organizationClient
-    .get(`/grants/${grantUuid}/reports/`)
+    .get(`/grants/${grantId}/reports/`)
     .then((response) => response.data.map(mapGrantReport));
 };
 
 // deleteGrantReport
 
-export const deleteGrantReport = (
-  organizationClient,
-  grantUuid,
-  reportUuid
-) => {
+export const deleteGrantReport = (organizationClient, grantId, reportId) => {
   return organizationClient
-    .delete(`/grants/${grantUuid}/reports/${reportUuid}`)
+    .delete(`/grants/${grantId}/reports/${reportId}`)
     .then((response) => response.data);
 };
 
@@ -49,12 +45,12 @@ export const deleteGrantReport = (
 
 export const createGrantReport = (
   organizationClient,
-  grantUuid,
+  grantId,
   newGrantReport
 ) => {
   return organizationClient
     .post(
-      `/grants/${grantUuid}/reports/`,
+      `/grants/${grantId}/reports/`,
       mapGrantReportToApiGrantReport(newGrantReport)
     )
     .then((response) => response.data);
@@ -64,13 +60,13 @@ export const createGrantReport = (
 
 export const updateGrantReport = (
   organizationClient,
-  grantUuid,
-  reportUuid,
+  grantId,
+  reportId,
   fieldsToUpdate
 ) => {
   return organizationClient
     .patch(
-      `/grants/${grantUuid}/reports/${reportUuid}`,
+      `/grants/${grantId}/reports/${reportId}`,
       mapGrantReportToApiGrantReport(fieldsToUpdate)
     )
     .then((response) => response.data);
@@ -80,13 +76,13 @@ export const updateGrantReport = (
 
 export const copyGrantReport = (
   organizationClient,
-  grantUuid,
-  reportUuid,
+  grantId,
+  reportId,
   copyGrantReportFields
 ) => {
   return organizationClient
     .post(
-      `/grants/${grantUuid}/reports/${reportUuid}/copy`,
+      `/grants/${grantId}/reports/${reportId}/copy`,
       mapGrantReportToApiGrantReport(copyGrantReportFields)
     )
     .then((response) => response.data);

--- a/src/Services/Organizations/Grants/Reports/ReportSectionsService.js
+++ b/src/Services/Organizations/Grants/Reports/ReportSectionsService.js
@@ -1,5 +1,5 @@
 export const mapReportSection = (apiReportSection) => ({
-  uuid: apiReportSection.uuid,
+  id: apiReportSection.id,
   wordCount: apiReportSection.wordcount,
   title: apiReportSection.title,
   text: apiReportSection.text,
@@ -13,26 +13,22 @@ const mapReportSectionToApiReportSection = (reportSection) => ({
 // getReportSection
 export const getReportSection = (
   organizationClient,
-  grantUuid,
-  reportUuid,
-  reportSectionUuid
+  grantId,
+  reportId,
+  reportSectionId
 ) => {
   return organizationClient
     .get(
-      `/grants/${grantUuid}/reports/${reportUuid}/report_sections/${reportSectionUuid}`
+      `/grants/${grantId}/reports/${reportId}/report_sections/${reportSectionId}`
     )
     .then((response) => response.data);
 };
 
 // listReportSections
 
-export const getAllReportSections = (
-  organizationClient,
-  grantUuid,
-  reportUuid
-) => {
+export const getAllReportSections = (organizationClient, grantId, reportId) => {
   return organizationClient
-    .get(`/grants/${grantUuid}/reports/${reportUuid}/report_sections/`)
+    .get(`/grants/${grantId}/reports/${reportId}/report_sections/`)
     .then((response) => response.data);
 };
 
@@ -40,13 +36,13 @@ export const getAllReportSections = (
 
 export const deleteReportSection = (
   organizationClient,
-  grantUuid,
-  reportUuid,
-  reportSectionUuid
+  grantId,
+  reportId,
+  reportSectionId
 ) => {
   return organizationClient
     .delete(
-      `/grants/${grantUuid}/reports/${reportUuid}/report_sections/${reportSectionUuid}`
+      `/grants/${grantId}/reports/${reportId}/report_sections/${reportSectionId}`
     )
     .then((response) => response.data);
 };
@@ -55,13 +51,13 @@ export const deleteReportSection = (
 
 export const createReportSection = (
   organizationClient,
-  grantUuid,
-  reportUuid,
+  grantId,
+  reportId,
   newReportSection
 ) => {
   return organizationClient
     .post(
-      `/grants/${grantUuid}/reports/${reportUuid}/report_sections`,
+      `/grants/${grantId}/reports/${reportId}/report_sections`,
       mapReportSectionToApiReportSection(newReportSection)
     )
     .then((response) => response.data);
@@ -71,14 +67,14 @@ export const createReportSection = (
 
 export const updateReportSection = (
   organizationClient,
-  grantUuid,
-  reportUuid,
-  reportSectionUuid,
+  grantId,
+  reportId,
+  reportSectionId,
   fieldsToUpdate
 ) => {
   return organizationClient
     .patch(
-      `/grants/${grantUuid}/reports/${reportUuid}/report_sections/${reportSectionUuid}/`,
+      `/grants/${grantId}/reports/${reportId}/report_sections/${reportSectionId}/`,
       mapReportSectionToApiReportSection(fieldsToUpdate)
     )
     .then((response) => response.data);

--- a/src/Services/Organizations/Grants/SectionsService.js
+++ b/src/Services/Organizations/Grants/SectionsService.js
@@ -1,58 +1,54 @@
 export const mapSection = (apiSection) => ({
-  uuid: apiSection.uuid,
+  id: apiSection.id,
   wordCount: apiSection.wordcount,
   title: apiSection.title,
   text: apiSection.text,
   sortOrder: apiSection.sort_order,
 });
 
-export const getSection = (organizationClient, grantUuid, sectionUuid) => {
+export const getSection = (organizationClient, grantId, sectionId) => {
   return organizationClient
-    .get(`/grants/${grantUuid}/sections/${sectionUuid}`)
+    .get(`/grants/${grantId}/sections/${sectionId}`)
     .then((response) => response.data);
 };
 
-export const getAllSections = (organizationClient, grantUuid) => {
+export const getAllSections = (organizationClient, grantId) => {
   return organizationClient
-    .get(`/grants/${grantUuid}/sections/`)
+    .get(`/grants/${grantId}/sections/`)
     .then((response) => response.data);
 };
 
-export const deleteSection = (organizationClient, grantUuid, sectionUuid) => {
+export const deleteSection = (organizationClient, grantId, sectionId) => {
   return organizationClient
-    .delete(`/grants/${grantUuid}/sections/${sectionUuid}`)
+    .delete(`/grants/${grantId}/sections/${sectionId}`)
     .then((response) => response.data);
 };
 
-export const createSection = (
-  organizationClient,
-  grantUuid,
-  newGrantSection
-) => {
+export const createSection = (organizationClient, grantId, newGrantSection) => {
   return organizationClient
-    .post(`/grants/${grantUuid}/sections/`, newGrantSection)
+    .post(`/grants/${grantId}/sections/`, newGrantSection)
     .then((response) => response.data);
 };
 
 export const updateSection = (
   organizationClient,
-  grantUuid,
-  sectionUuid,
+  grantId,
+  sectionId,
   fieldsToUpdate
 ) => {
   return organizationClient
-    .patch(`/grants/${grantUuid}/sections/${sectionUuid}`, fieldsToUpdate)
+    .patch(`/grants/${grantId}/sections/${sectionId}`, fieldsToUpdate)
     .then((response) => response.data);
 };
 
 export const reorderSection = (
   organizationClient,
-  grantUuid,
-  sectionUuid,
+  grantId,
+  sectionId,
   sortOrder
 ) => {
   return organizationClient
-    .patch(`/grants/${grantUuid}/actions/reorder_section/${sectionUuid}`, {
+    .patch(`/grants/${grantId}/actions/reorder_section/${sectionId}`, {
       sort_order: sortOrder,
     })
     .then((response) => response.data);

--- a/src/Services/Organizations/GrantsService.js
+++ b/src/Services/Organizations/GrantsService.js
@@ -4,10 +4,10 @@ const mapGrant = (apiGrant) => ({
   archived: apiGrant.archived,
   createdAt: new Date(apiGrant.created_at),
   deadline: new Date(apiGrant.deadline),
-  fundingOrgUuid: apiGrant.funding_org_uuid,
+  fundingOrgId: apiGrant.funding_org_id,
   fundingOrgName: apiGrant.funding_org_name,
-  uuid: apiGrant.uuid,
-  organizationUuid: apiGrant.organization_uuid,
+  id: apiGrant.id,
+  organizationId: apiGrant.organization_id,
   purpose: apiGrant.purpose,
   rfpUrl: apiGrant.rfp_url,
   submitted: apiGrant.submitted,
@@ -20,14 +20,14 @@ const mapGrant = (apiGrant) => ({
 const mapGrantToApiGrant = (grant) => ({
   ...grant,
   rfp_url: grant.rfpUrl,
-  funding_org_id: grant.fundingOrgUuid,
-  organization_id: grant.organizationUuid,
+  funding_org_id: grant.fundingOrgId,
+  organization_id: grant.organizationId,
 });
 
 // getGrant
-export const getGrant = (organizationClient, grantUuid) => {
+export const getGrant = (organizationClient, grantId) => {
   return organizationClient
-    .get(`/grants/${grantUuid}`)
+    .get(`/grants/${grantId}`)
     .then((response) => mapGrant(response.data));
 };
 
@@ -41,9 +41,9 @@ export const getAllGrants = (organizationClient) => {
 
 // deleteGrant
 
-export const deleteGrant = (organizationClient, grantUuid) => {
+export const deleteGrant = (organizationClient, grantId) => {
   return organizationClient
-    .delete(`/grants/${grantUuid}`)
+    .delete(`/grants/${grantId}`)
     .then((response) => response.data);
 };
 
@@ -57,16 +57,16 @@ export const createGrant = (organizationClient, newGrant) => {
 
 // updateGrant
 
-export const updateGrant = (organizationClient, grantUuid, fieldsToUpdate) => {
+export const updateGrant = (organizationClient, grantId, fieldsToUpdate) => {
   return organizationClient
-    .patch(`/grants/${grantUuid}`, mapGrantToApiGrant(fieldsToUpdate))
+    .patch(`/grants/${grantId}`, mapGrantToApiGrant(fieldsToUpdate))
     .then((response) => response.data);
 };
 
 // copyGrant
 
-export const copyGrant = (organizationClient, grantUuid, copyGrantFields) => {
+export const copyGrant = (organizationClient, grantId, copyGrantFields) => {
   return organizationClient
-    .post(`/grants/${grantUuid}/copy`, mapGrantToApiGrant(copyGrantFields))
+    .post(`/grants/${grantId}/copy`, mapGrantToApiGrant(copyGrantFields))
     .then((response) => response.data);
 };


### PR DESCRIPTION
## 🤺 Summary
This PR finishes the frontend changes for this ticket: #352 

In a previous PR, we added UUID to the frontend; this ticket removes the UUID as a separate column in addition to the ID, and changes the frontend to reference only the ID and to reference the ID as a primary key. 

## 📝 Checklist
* [ x] Are tests & linter passing?
* [ x] Are relevant tickets linked to this PR?
* [ x] Are reviews assigned to this PR?
* [x ] Are there any deployment considerations? 
  * [ x] Environment variables? n/a
  * [ x] External dependencies? (apis, dbs, infrastructure) n/a
  * [ x] Data or schema migrations? <----there are migrations on the corresponding backend branch for this ticket, 353/remove-ids-from-api

## 🧶 Steps to run
before testing, check out on the backend to 353/remove-ids-from-api and run rake db:migrate 

## 🔬 Steps to test
see above re: backend
start the frontend in the browser and click around to make sure that the routes & functions all still work as normal. You should see UUIDs - strings of letters and integers - in lieu of sequential numerical ids. 
