### PR TITLE
Move password reset token into url

### DIFF
--- a/src/Components/Login/ResetPassword/ResetPassword.css
+++ b/src/Components/Login/ResetPassword/ResetPassword.css
@@ -1,6 +1,4 @@
 .reset-password {
-  display: flex;
-  width: 100%;
   max-width: 50%;
   margin: auto;
   padding-top: 8rem;
@@ -10,5 +8,8 @@
   display: flex;
   text-decoration: none;
   align-items: center;
-  padding-top: 2rem;
+}
+
+.reset-password__back-button > svg {
+  font-size: var(--font-size-icon);
 }

--- a/src/Components/Login/ResetPassword/ResetPassword.css
+++ b/src/Components/Login/ResetPassword/ResetPassword.css
@@ -12,7 +12,3 @@
   align-items: center;
   padding-top: 2rem;
 }
-
-.reset-password__header {
-  margin: 1rem 0 3rem 0;
-}

--- a/src/Components/Login/ResetPassword/ResetPassword.jsx
+++ b/src/Components/Login/ResetPassword/ResetPassword.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useHistory } from "react-router-dom";
 import Container from "../../design/Container/Container";
 import ResetPasswordForm from "./ResetPasswordForm";
@@ -6,9 +6,13 @@ import "./ResetPassword.css";
 import axios from "axios";
 import { Link } from "react-router-dom";
 import { MdChevronLeft } from "react-icons/md";
+import useQuery from "../../../Hooks/useQuery";
 
 export default function ResetPassword() {
   const history = useHistory();
+  const query = useQuery();
+  const token = useMemo(() => query.get("token"), [query]);
+
   const handleSubmit = (resetPasswordFields) => {
     resetPassword(resetPasswordFields);
     history.push("/splashpage");
@@ -16,7 +20,7 @@ export default function ResetPassword() {
 
   const resetPassword = (credentials) => {
     axios
-      .post("api/reset_password", credentials)
+      .post("api/reset_password", { ...credentials, token })
       .then((response) => {
         if (response) {
           alert(response.data.message);
@@ -26,17 +30,15 @@ export default function ResetPassword() {
   };
 
   return (
-    <>
-      <div className="reset-password">
-        <Container as="section" centered>
-          <Link className="reset-password__back-button" to="/splashpage">
-            <MdChevronLeft />
-            Back to Splashpage
-          </Link>
-          <h1 className="reset-password__header">Reset Password</h1>
-          <ResetPasswordForm onSubmit={handleSubmit} />
-        </Container>
-      </div>
-    </>
+    <div className="reset-password">
+      <Container as="section" centered>
+        <Link className="reset-password__back-button" to="/splashpage">
+          <MdChevronLeft />
+          Back to Splashpage
+        </Link>
+        <h1 className="reset-password__header">Reset Password</h1>
+        <ResetPasswordForm onSubmit={handleSubmit} />
+      </Container>
+    </div>
   );
 }

--- a/src/Components/Login/ResetPassword/ResetPassword.jsx
+++ b/src/Components/Login/ResetPassword/ResetPassword.jsx
@@ -30,15 +30,25 @@ export default function ResetPassword() {
   };
 
   return (
-    <div className="reset-password">
-      <Container as="section" centered>
-        <Link className="reset-password__back-button" to="/splashpage">
-          <MdChevronLeft />
-          Back to Splashpage
-        </Link>
-        <h1 className="reset-password__header">Reset Password</h1>
-        <ResetPasswordForm onSubmit={handleSubmit} />
-      </Container>
-    </div>
+    <Container as="section" centered className="reset-password">
+      {token ? (
+        <>
+          <Link className="reset-password__back-button" to="/splashpage">
+            <MdChevronLeft />
+            Back to Splashpage
+          </Link>
+          <h1 className="reset-password__header">Reset Password</h1>
+          <ResetPasswordForm onSubmit={handleSubmit} />
+        </>
+      ) : (
+        <>
+          <h1 className="reset-password__header">Something went wrong</h1>
+          <p>
+            Please try resetting your password again{" "}
+            <Link to="/splashpage">from the splashpage.</Link>
+          </p>
+        </>
+      )}
+    </Container>
   );
 }

--- a/src/Components/Login/ResetPassword/ResetPassword.jsx
+++ b/src/Components/Login/ResetPassword/ResetPassword.jsx
@@ -12,6 +12,7 @@ export default function ResetPassword() {
   const history = useHistory();
   const query = useQuery();
   const token = useMemo(() => query.get("token"), [query]);
+  const email = useMemo(() => query.get("email"), [query]);
 
   const handleSubmit = (resetPasswordFields) => {
     resetPassword(resetPasswordFields);
@@ -20,7 +21,7 @@ export default function ResetPassword() {
 
   const resetPassword = (credentials) => {
     axios
-      .post("api/reset_password", { ...credentials, token })
+      .post("api/reset_password", { ...credentials, token, email })
       .then((response) => {
         if (response) {
           alert(response.data.message);
@@ -31,13 +32,14 @@ export default function ResetPassword() {
 
   return (
     <Container as="section" centered className="reset-password">
-      {token ? (
+      {token && email ? (
         <>
           <Link className="reset-password__back-button" to="/splashpage">
             <MdChevronLeft />
             Back to Splashpage
           </Link>
           <h1 className="reset-password__header">Reset Password</h1>
+          <p>Enter the new password for {email}.</p>
           <ResetPasswordForm onSubmit={handleSubmit} />
         </>
       ) : (

--- a/src/Components/Login/ResetPassword/ResetPassword.jsx
+++ b/src/Components/Login/ResetPassword/ResetPassword.jsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from "react";
-import { useHistory } from "react-router-dom";
-import Container from "../../design/Container/Container";
-import ResetPasswordForm from "./ResetPasswordForm";
-import "./ResetPassword.css";
-import axios from "axios";
-import { Link } from "react-router-dom";
+import { useMutation } from "react-query";
+import { useHistory, Link } from "react-router-dom";
 import { MdChevronLeft } from "react-icons/md";
+import Container from "../../design/Container/Container";
 import useQuery from "../../../Hooks/useQuery";
+import ResetPasswordForm from "./ResetPasswordForm";
+import * as PasswordService from "../../../Services/Auth/PasswordService";
+import "./ResetPassword.css";
 
 export default function ResetPassword() {
   const history = useHistory();
@@ -16,19 +16,30 @@ export default function ResetPassword() {
 
   const handleSubmit = (resetPasswordFields) => {
     resetPassword(resetPasswordFields);
-    history.push("/splashpage");
   };
 
-  const resetPassword = (credentials) => {
-    axios
-      .post("api/reset_password", { ...credentials, token, email })
-      .then((response) => {
-        if (response) {
-          alert(response.data.message);
-        }
-      })
-      .catch((error) => console.error(error));
-  };
+  const { mutate: resetPassword } = useMutation(
+    (credentials) =>
+      PasswordService.resetPassword({
+        ...credentials,
+        token,
+        email,
+      }),
+    {
+      onSuccess: (response) => {
+        alert(response.data.message);
+      },
+      onError(error) {
+        console.error(error);
+        alert(
+          "Invalid login information given. Please try resetting your password again."
+        );
+      },
+      onSettled() {
+        history.push("/splashpage");
+      },
+    }
+  );
 
   return (
     <Container as="section" centered className="reset-password">

--- a/src/Components/Login/ResetPassword/ResetPasswordForm.jsx
+++ b/src/Components/Login/ResetPassword/ResetPasswordForm.jsx
@@ -4,15 +4,15 @@ import TextBox from "../../design/TextBox/TextBox";
 import "./ResetPasswordForm.css";
 
 export default function ResetPasswordForm(props) {
-  const [resetPasswordFields, setResetPasswordFields] = useState({});
+  const [newPassword, setNewPassword] = useState("");
+  const [newPasswordConfirmation, setNewPasswordConfirmation] = useState("");
+
   const handleSubmit = (event) => {
     event.preventDefault();
-    if (
-      resetPasswordFields.password !== resetPasswordFields.passwordConfirmation
-    ) {
+    if (newPassword !== newPasswordConfirmation) {
       alert("Passwords don't match");
     } else {
-      props.onSubmit(resetPasswordFields);
+      props.onSubmit({ password: newPassword });
     }
   };
 
@@ -23,13 +23,8 @@ export default function ResetPasswordForm(props) {
         name="password"
         labelText="New Password"
         placeholder="New Password"
-        value={resetPasswordFields.password}
-        onChange={(event) =>
-          setResetPasswordFields({
-            ...resetPasswordFields,
-            password: event.target.value,
-          })
-        }
+        value={newPassword}
+        onChange={(event) => setNewPassword(event.target.value)}
         required
       />
       <TextBox
@@ -37,13 +32,8 @@ export default function ResetPasswordForm(props) {
         name="passwordConfirmation"
         labelText="Password Confirmation"
         placeholder="Password Confirmation"
-        value={resetPasswordFields.passwordConfirmation}
-        onChange={(event) =>
-          setResetPasswordFields({
-            ...resetPasswordFields,
-            passwordConfirmation: event.target.value,
-          })
-        }
+        value={newPasswordConfirmation}
+        onChange={(event) => setNewPasswordConfirmation(event.target.value)}
         required
       />
       <div className="reset-password-form__actions">

--- a/src/Components/Login/ResetPassword/ResetPasswordForm.jsx
+++ b/src/Components/Login/ResetPassword/ResetPasswordForm.jsx
@@ -19,20 +19,6 @@ export default function ResetPasswordForm(props) {
   return (
     <form onSubmit={handleSubmit} className="forgot-password-form">
       <TextBox
-        type="email"
-        name="email"
-        labelText="Email"
-        placeholder="Email"
-        value={resetPasswordFields.email}
-        onChange={(event) =>
-          setResetPasswordFields({
-            ...resetPasswordFields,
-            email: event.target.value,
-          })
-        }
-        required
-      />
-      <TextBox
         type="password"
         name="password"
         labelText="New Password"

--- a/src/Components/Login/ResetPassword/ResetPasswordForm.jsx
+++ b/src/Components/Login/ResetPassword/ResetPasswordForm.jsx
@@ -17,78 +17,58 @@ export default function ResetPasswordForm(props) {
   };
 
   return (
-    <div>
-      <p className="reset-password-form__header-text">
-        Please enter the token that was emailed to you in the form below. This
-        reset form is case sensitive.
-      </p>
-      <form onSubmit={handleSubmit} className="forgot-password-form">
-        <TextBox
-          type="token"
-          name="token"
-          labelText="Token"
-          placeholder="Token"
-          value={resetPasswordFields.token}
-          onChange={(event) =>
-            setResetPasswordFields({
-              ...resetPasswordFields,
-              token: event.target.value,
-            })
-          }
-          required
-        />
-        <TextBox
-          type="email"
-          name="email"
-          labelText="Email"
-          placeholder="Email"
-          value={resetPasswordFields.email}
-          onChange={(event) =>
-            setResetPasswordFields({
-              ...resetPasswordFields,
-              email: event.target.value,
-            })
-          }
-          required
-        />
-        <TextBox
-          type="password"
-          name="password"
-          labelText="New Password"
-          placeholder="New Password"
-          value={resetPasswordFields.password}
-          onChange={(event) =>
-            setResetPasswordFields({
-              ...resetPasswordFields,
-              password: event.target.value,
-            })
-          }
-          required
-        />
-        <TextBox
-          type="password"
-          name="passwordConfirmation"
-          labelText="Password Confirmation"
-          placeholder="Password Confirmation"
-          value={resetPasswordFields.passwordConfirmation}
-          onChange={(event) =>
-            setResetPasswordFields({
-              ...resetPasswordFields,
-              passwordConfirmation: event.target.value,
-            })
-          }
-          required
-        />
-        <div className="reset-password-form__actions">
-          <Button
-            variant="none"
-            type="submit"
-            className="reset-password-form__reset-password-submit-button"
-          >
-            Submit
-          </Button>
-        </div>
-      </form>
-    </div>
+    <form onSubmit={handleSubmit} className="forgot-password-form">
+      <TextBox
+        type="email"
+        name="email"
+        labelText="Email"
+        placeholder="Email"
+        value={resetPasswordFields.email}
+        onChange={(event) =>
+          setResetPasswordFields({
+            ...resetPasswordFields,
+            email: event.target.value,
+          })
+        }
+        required
+      />
+      <TextBox
+        type="password"
+        name="password"
+        labelText="New Password"
+        placeholder="New Password"
+        value={resetPasswordFields.password}
+        onChange={(event) =>
+          setResetPasswordFields({
+            ...resetPasswordFields,
+            password: event.target.value,
+          })
+        }
+        required
+      />
+      <TextBox
+        type="password"
+        name="passwordConfirmation"
+        labelText="Password Confirmation"
+        placeholder="Password Confirmation"
+        value={resetPasswordFields.passwordConfirmation}
+        onChange={(event) =>
+          setResetPasswordFields({
+            ...resetPasswordFields,
+            passwordConfirmation: event.target.value,
+          })
+        }
+        required
+      />
+      <div className="reset-password-form__actions">
+        <Button
+          variant="none"
+          type="submit"
+          className="reset-password-form__reset-password-submit-button"
+        >
+          Submit
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/src/Hooks/useQuery.js
+++ b/src/Hooks/useQuery.js
@@ -1,0 +1,8 @@
+import { useMemo } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function useQuery() {
+  const { search } = useLocation();
+
+  return useMemo(() => new URLSearchParams(search), [search]);
+}

--- a/src/Hooks/useQuery.js
+++ b/src/Hooks/useQuery.js
@@ -1,6 +1,18 @@
 import { useMemo } from "react";
 import { useLocation } from "react-router-dom";
 
+/**
+ * @example
+ *
+ * // url = 'http://localhost:3001?token=abc&email=
+ * // token = abc
+ * // email = ''
+ * // something = null
+ * const query = useQuery()
+ * const token = useMemo(() => query.get('token'), [query])
+ * const email = useMemo(() => query.get('email'), [query])
+ * const something = useMemo(() => query.get('something'), [query])
+ */
 export default function useQuery() {
   const { search } = useLocation();
 

--- a/src/Services/Auth/PasswordService.js
+++ b/src/Services/Auth/PasswordService.js
@@ -1,0 +1,12 @@
+import apiClient from "../../config/apiClient";
+
+/**
+ * Resets a user's password using a reset token.
+ * @param {object} credentials
+ * @param {string} credentials.token
+ * @param {string} credentials.email
+ * @param {string} credentials.password
+ */
+export async function resetPassword(credentials) {
+  return apiClient.post("/reset_password", credentials);
+}


### PR DESCRIPTION
## 🤺 Summary
<!-- Describe the changes being introduced, providing any necessary context. Screenshots are welcome! -->
Closes #400

This adjusts the password reset flow to expect the token to be in the url under the `token` query param (instead of having the user copy/paste if from their email).

## 📝 Checklist
<!-- Check steps as necessary - this list is a reminder -->
* [x] Are tests & linter passing?
* [x] Are relevant tickets linked to this PR?
* [x] Are reviews assigned to this PR?

## 🔬 Steps to test

Checkout to the corresponding API branch: https://github.com/Jess-White/boilerplate_api/pull/100:
```sh
$ git checkout feature/400-update-password-reset-flow-to-put-token-in-url
```

Next, make sure your `.env` in the api has the following envs set:
```sh
ACTION_MAILER_GMAIL_ACCOUNT="TODO"
ACTION_MAILER_GMAIL_PASSWORD="TODO"
```

Now test the two flows:

Flow A: Testing updated flow:
1. Go to splashpage - `/splashpage`
2. Click "Forgot Password" link - modal should open
3. Enter your account's email - email should be sent
4. Open email and expect the body to have been slightly updated - raw token should be gone because it's now embedded in the link
5. Click on the link - you should be brought to `/reset_password?token=GENERATED_TOKEN`
6. Expect to see slightly updated page - token input box should be gone
7. Fill out form & submit - password should be reset (try logging in)

Flow B: Testing invalid link:
1. Go to  `/reset_password?token=`
2. Expect to see a different "error" page that instructs the user to try resetting their password again
3. Go to `/reset_password`
4. Expect to see the same "error" page