### PR TITLE
Redirect to create organization if not in organization

### DIFF
--- a/src/Components/Organizations/OrganizationIndex.jsx
+++ b/src/Components/Organizations/OrganizationIndex.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import React, { useState, useEffect } from "react";
+import { Link, useHistory } from "react-router-dom";
 import { useCurrentUser } from "../../Contexts/currentUserContext";
 import useCreateOrganization from "../../Hooks/useCreateOrganization";
 import OrganizationCard from "./OrganizationIndex/OrganizationCard";
@@ -13,12 +13,19 @@ import "./OrganizationIndex.css";
 
 function OrganizationIndex() {
   const { organizations } = useCurrentUser();
+  const history = useHistory();
   const [isNewOrganizationModalOpen, setIsNewOrganizationModalOpen] =
     useState(false);
 
   const createOrganization = useCreateOrganization({
     onSuccess: () => setIsNewOrganizationModalOpen(false),
   });
+
+  useEffect(() => {
+    if (organizations.length === 0) {
+      history.push("/organizations/new");
+    }
+  }, [history, organizations]);
 
   return (
     <Background>

--- a/src/Components/Organizations/OrganizationNew.jsx
+++ b/src/Components/Organizations/OrganizationNew.jsx
@@ -15,7 +15,7 @@ function OrganizationNew() {
 
   return (
     <Container as="section" className="organization-new">
-      <h1>Add Organization</h1>
+      <h1>Create Organization</h1>
       <OrganizationForm onSubmit={createOrganization} onCancel={handleCancel} />
     </Container>
   );


### PR DESCRIPTION
## 🤺 Summary
<!-- Describe the changes being introduced, providing any necessary context. Screenshots are welcome! -->
Closes #401

This makes a small tweak where when users login, if they aren't apart of any organizations, they're brought to the Create Organization page (instead of organization index).

## 📝 Checklist
<!-- Check steps as necessary - this list is a reminder -->
* [x] Are tests & linter passing?
* [x] Are relevant tickets linked to this PR?
* [x] Are reviews assigned to this PR?

## 🔬 Steps to test
1. Login with user in no organizations
2. Expect to be brought to organizations new page
3. Login with user in at least 1 organization
4. Expect to be brought to the organization index page