### PR TITLE
Implement user index page

### DIFF
--- a/src/Components/design/TextBox/TextBox.jsx
+++ b/src/Components/design/TextBox/TextBox.jsx
@@ -52,6 +52,7 @@ TextBox.propTypes = {
   suffix: PropTypes.node,
   type: PropTypes.string,
   value: PropTypes.string,
+  search: PropTypes.bool,
 };
 
 TextBox.defaultProps = {

--- a/src/pages/UserIndex/UserIndexPage.css
+++ b/src/pages/UserIndex/UserIndexPage.css
@@ -1,0 +1,13 @@
+.user-index {
+  flex: 1;
+  padding: 4rem;
+}
+
+.user-index__search-input {
+  width: 40vw;
+  margin-bottom: 0px;
+}
+
+.user-index__table {
+  width: 100%;
+}

--- a/src/pages/UserIndex/UserIndexPage.jsx
+++ b/src/pages/UserIndex/UserIndexPage.jsx
@@ -15,7 +15,9 @@ export default function UserIndexPage() {
   const filteredUsers = useMemo(() => {
     return users.filter((user) => {
       const userFullName = `${user.firstName} ${user.lastName}`;
-      return userFullName.toLowerCase().includes(searchString.toLowerCase());
+      return userFullName
+        .toLowerCase()
+        .includes(searchString.toLowerCase().trim());
     });
   }, [users, searchString]);
 

--- a/src/pages/UserIndex/UserIndexPage.jsx
+++ b/src/pages/UserIndex/UserIndexPage.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useMemo, useContext } from "react";
+import { useQuery } from "react-query";
+import * as OrganizationService from "../../Services/OrganizationService";
+import { CurrentOrganizationContext } from "../../Contexts/currentOrganizationContext";
+import Table from "../../Components/design/Table/Table";
+import TextBox from "../../Components/design/TextBox/TextBox";
+import "./UserIndexPage.css";
+
+export default function UserIndexPage() {
+  const { organizationClient } = useContext(CurrentOrganizationContext);
+  const [searchString, setSearchString] = useState("");
+  const { data: users } = useQuery("getUsers", () =>
+    OrganizationService.getAllOrganizationUsers(organizationClient)
+  );
+  const filteredUsers = useMemo(() => {
+    return users.filter((user) => {
+      const userFullName = `${user.firstName} ${user.lastName}`;
+      return userFullName.toLowerCase().includes(searchString.toLowerCase());
+    });
+  }, [users, searchString]);
+
+  const columns = [
+    { Header: "First Name", accessor: "firstName" },
+    { Header: "Last Name", accessor: "lastName" },
+    { Header: "Email", accessor: "email" },
+  ];
+
+  return (
+    <section className="user-index">
+      <h1>All Users</h1>
+      <div className="user-index__actions">
+        <TextBox
+          labelText="Search Users by Name"
+          search
+          onChange={(event) => setSearchString(event.target.value)}
+          className="user-index__search-input"
+        />
+      </div>
+      {filteredUsers.length ? (
+        <Table
+          className="user-index__table"
+          columns={columns}
+          data={filteredUsers}
+        />
+      ) : (
+        <p>No users found.</p>
+      )}
+    </section>
+  );
+}

--- a/src/routes/OrganizationRoutes.jsx
+++ b/src/routes/OrganizationRoutes.jsx
@@ -19,7 +19,7 @@ import GrantsNew from "../Components/Grants/GrantsNew";
 import ReportsNew from "../Components/Reports/ReportsNew";
 import ReportsShow from "../Components/Reports/ReportsShow";
 import RedirectToDashboard from "../Components/Helpers/RedirectToDashboard";
-import StayTunedPage from "../pages/StayTuned/StayTunedPage";
+import UserIndexPage from "../pages/UserIndex/UserIndexPage";
 
 export default function OrganizationRoutes() {
   return (
@@ -94,7 +94,7 @@ export default function OrganizationRoutes() {
             />
             <Route
               path="/organizations/:organizationId/users"
-              component={StayTunedPage}
+              component={UserIndexPage}
             />
             <Route path="*">
               <RedirectToDashboard />


### PR DESCRIPTION
## 🤺 Summary
<!-- Describe the changes being introduced, providing any necessary context. Screenshots are welcome! -->

Closes #234 

Adds a new page that displays a table of the users in the organization.

<img width="2102" alt="image" src="https://user-images.githubusercontent.com/23223956/188200363-7ef57e81-7ede-4782-a78e-68b139f12d90.png">

## 📝 Checklist
<!-- Check steps as necessary - this list is a reminder -->
* [x] Are tests & linter passing?
* [x] Are relevant tickets linked to this PR?
* [x] Are reviews assigned to this PR?

## 🔬 Steps to test
1. Login
2. Go to organization
3. Click "Users" link in sidebar
4. Expect to see the amazing user index page!
5. Expect to be able to filter by a combination of first name/last name