### PR TITLE
Bug/405 fix navbar button alignment

### DIFF
--- a/src/Components/Layouts/SplashpageLayout/SplashpageLayout.css
+++ b/src/Components/Layouts/SplashpageLayout/SplashpageLayout.css
@@ -3,6 +3,10 @@
   background-size: cover;
 }
 
+.splashpage-layout__scroll-padding {
+  padding-right: calc(100vw - 100%);
+}
+
 .splashpage-layout__navbar-container {
   position: absolute;
   width: 100%;
@@ -18,7 +22,7 @@
   height: auto;
 }
 
-.splashpage-layout__noscroll { 
+.splashpage-layout__noscroll {
   overflow: hidden;
   position: fixed;
 }

--- a/src/Components/Layouts/SplashpageLayout/SplashpageLayout.css
+++ b/src/Components/Layouts/SplashpageLayout/SplashpageLayout.css
@@ -3,22 +3,22 @@
   background-size: cover;
 }
 
-/* .splashpage-layout__scroll-padding {
-  padding-right: calc(100vw - 100%);
-} */
-
 .splashpage-layout__navbar-container {
   position: absolute;
   width: 100%;
   z-index: 1;
-  /* padding-left: calc(100vw - 100%); */
-  /* position: fixed; */
-  /* overflow: hidden;
-  position: fixed; */
 }
 
-.splashpage-layout__navbar-container-open-panel {
-  padding-left: calc(100vw - 100%);
+/* These conditional classes are designed to account for scrollbar widths from across multiple browsers - 
+the scrollBarWidth function calculates the scrollbar width and passes it into this class name */
+.splashpage-layout__scrollbar_padding_12 {
+  padding-right: 12px;
+}
+.splashpage-layout__scrollbar_padding_15 {
+  padding-right: 15px;
+}
+.splashpage-layout__scrollbar_padding_17 {
+  padding-right: 17px;
 }
 
 .splashpage-layout__content {

--- a/src/Components/Layouts/SplashpageLayout/SplashpageLayout.css
+++ b/src/Components/Layouts/SplashpageLayout/SplashpageLayout.css
@@ -3,15 +3,24 @@
   background-size: cover;
 }
 
-.splashpage-layout__scroll-padding {
+/* .splashpage-layout__scroll-padding {
   padding-right: calc(100vw - 100%);
-}
+} */
 
 .splashpage-layout__navbar-container {
   position: absolute;
   width: 100%;
   z-index: 1;
+  /* padding-left: calc(100vw - 100%); */
+  /* position: fixed; */
+  /* overflow: hidden;
+  position: fixed; */
 }
+
+.splashpage-layout__navbar-container-open-panel {
+  padding-left: calc(100vw - 100%);
+}
+
 .splashpage-layout__content {
   display: flex;
   position: relative;

--- a/src/Components/Layouts/SplashpageLayout/SplashpageLayout.jsx
+++ b/src/Components/Layouts/SplashpageLayout/SplashpageLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import NavbarSplashpage from "../../design/Navbar/NavbarSplashpage/NavbarSplashpage";
 import "./SplashpageLayout.css";
 import splashpageBackgroundImage from "./splashpage_background_image7.png";
@@ -20,6 +20,17 @@ export default function SplashpageLayout() {
   const [modalLabel, setModalLabel] = useState("Loading");
   const [modalContents, setModalContents] = useState(<></>);
   const [panelView, setPanelView] = useState("");
+  const [scrollbarWidth, setScrollbarWidth] = useState(15);
+
+  useEffect(() => {
+    const currentWidth = calculateScrollbarWidth();
+    if (!panelView && currentWidth > 0) {
+      setScrollbarWidth(calculateScrollbarWidth());
+    }
+  }, [panelView]);
+
+  const calculateScrollbarWidth = () =>
+    window.innerWidth - document.documentElement.offsetWidth;
 
   const textForCopyright = () => {
     return `Copyright Jess White and Michael McFaddin 2020 - ${new Date().getFullYear()}`;
@@ -106,7 +117,8 @@ export default function SplashpageLayout() {
       <div
         className={clsx(
           "splashpage-layout__navbar-container",
-          panelView || "splashpage-layout__navbar-container-open-panel"
+          panelView &&
+            `splashpage-layout__scrollbar_padding_${scrollbarWidth.toString()}`
         )}
       >
         <NavbarSplashpage

--- a/src/Components/Layouts/SplashpageLayout/SplashpageLayout.jsx
+++ b/src/Components/Layouts/SplashpageLayout/SplashpageLayout.jsx
@@ -108,7 +108,12 @@ export default function SplashpageLayout() {
         panelView && "splashpage-layout__noscroll"
       )}
     >
-      <div className="splashpage-layout__navbar-container">
+      <div
+        className={clsx(
+          "splashpage-layout__navbar-container",
+          panelView || "splashpage-layout__scroll-padding"
+        )}
+      >
         <NavbarSplashpage
           toggleModalContents={handleSwitchSplashPageModal}
           togglePanelContents={setPanelView}

--- a/src/Components/Layouts/SplashpageLayout/SplashpageLayout.jsx
+++ b/src/Components/Layouts/SplashpageLayout/SplashpageLayout.jsx
@@ -102,16 +102,11 @@ export default function SplashpageLayout() {
   };
 
   return (
-    <main
-      className={clsx(
-        "splashpage-layout",
-        panelView && "splashpage-layout__noscroll"
-      )}
-    >
+    <div>
       <div
         className={clsx(
           "splashpage-layout__navbar-container",
-          panelView || "splashpage-layout__scroll-padding"
+          panelView || "splashpage-layout__navbar-container-open-panel"
         )}
       >
         <NavbarSplashpage
@@ -119,23 +114,30 @@ export default function SplashpageLayout() {
           togglePanelContents={setPanelView}
         />
       </div>
-      <div className="splashpage-layout__content">
-        <img
-          src={splashpageBackgroundImage}
-          alt="Splashpage graphics"
-          className="splashpage-layout__background-image"
-        />
-        <Modal
-          hide={handleCloseSplashPageModal}
-          show={showSplashPageModal}
-          heading={modalLabel}
-          splashpageForm={true}
-        >
-          {modalContents}
-        </Modal>
-        {handleSwitchSplashPagePanel()}
-      </div>
-      <Footer footerText={textForCopyright()} />
-    </main>
+      <main
+        className={clsx(
+          "splashpage-layout",
+          panelView && "splashpage-layout__noscroll"
+        )}
+      >
+        <div className="splashpage-layout__content">
+          <img
+            src={splashpageBackgroundImage}
+            alt="Splashpage graphics"
+            className="splashpage-layout__background-image"
+          />
+          <Modal
+            hide={handleCloseSplashPageModal}
+            show={showSplashPageModal}
+            heading={modalLabel}
+            splashpageForm={true}
+          >
+            {modalContents}
+          </Modal>
+          {handleSwitchSplashPagePanel()}
+        </div>
+        <Footer footerText={textForCopyright()} />
+      </main>
+    </div>
   );
 }

--- a/src/Components/design/Navbar/NavbarSplashpage/NavbarSplashpage.css
+++ b/src/Components/design/Navbar/NavbarSplashpage/NavbarSplashpage.css
@@ -2,7 +2,6 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
-  border-right: 1px solid var(--contrast-10);
 }
 
 .navbar-splashpage__logo {
@@ -33,45 +32,45 @@
 }
 
 .navbar__tab-text {
-    position: absolute;
-    top: 60%;
-    left: 25%;
-    transform: translate(-28%, -60%);
-    color: #2C92A8;
-    /* font-size: var(--;font-size-small);
+  position: absolute;
+  top: 60%;
+  left: 25%;
+  transform: translate(-28%, -60%);
+  color: #2c92a8;
+  /* font-size: var(--;font-size-small);
     font-weight: var(--font-weight-bold); */
-    font-size: var(--font-size-large-1);
-    font-weight: var(--font-weight-extra-bold);
-    text-transform: uppercase;
-    letter-spacing: .2rem;
+  font-size: var(--font-size-large-1);
+  font-weight: var(--font-weight-extra-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.2rem;
 }
 
 .tab-pink:hover {
-  color: #4B1E75;
+  color: #4b1e75;
 }
 
 .tab-blue:hover {
-  color: #237E74
+  color: #237e74;
 }
 
 .tab-yellow:hover {
-  color: #F6A04D
+  color: #f6a04d;
 }
 
 .tab-login {
-  color: #4B1E75;
+  color: #4b1e75;
 }
 
 .tab-login:hover {
-  color: #237E74;
+  color: #237e74;
 }
 
 .tab-signup {
-  color: #4B1E75;
+  color: #4b1e75;
 }
 
 .tab-signup:hover {
-  color: #E3ED55
+  color: #e3ed55;
 }
 
 .navbar__button {


### PR DESCRIPTION
## 🤺 Summary
This PR fixes the navbar shift to the right on the splashpage when one of the panels (Our Team, Feature, Contacts) opens. The shift is caused by the removal of the scroll bar on the right side of the NavbarSplashpage component when a panel opens. The fix is to calculate what the scrollbar width is and add additional padding-right to the div wrapping the NavbarSplashpage.

---NOTE--- This branch pulls in PR #354, #421 and #426 which may have not been merged at the time of this PR review.

## 📝 Checklist
* [x] Are tests & linter passing?
* [x] Are relevant tickets linked to this PR? [#405](https://github.com/Jess-White/boilerplate/projects/18#card-85351383)
* [x] Are reviews assigned to this PR?

## 🧶 Steps to run
* No changes.

## 🔬 Steps to test
* Navigate to the splashpage.
* Open any of the panels such as Our Team, Features and Contact.
* You should not see any shift in the navbar when opening or closing any of the 3 panels.
