### PR TITLE
Feature/grant section dnd/439 revert order functionality to previous state

### DIFF
--- a/src/Components/Grants/GrantShowOverview.css
+++ b/src/Components/Grants/GrantShowOverview.css
@@ -35,3 +35,7 @@
   justify-content: flex-end;
   padding-bottom: 1.4rem;
 }
+
+.grants-show-overview__save-button .button{
+  margin-left: 1rem;
+}

--- a/src/Components/Grants/GrantShowOverview.jsx
+++ b/src/Components/Grants/GrantShowOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import { useQuery, useMutation } from "react-query";
 import { useParams } from "react-router-dom";
 import Button from "../design/Button/Button";
@@ -57,31 +57,27 @@ export default function GrantShowOverview(props) {
   };
 
   useEffect(() => {
-    props.setReorderHistory([...[], props.sortableSections]);
+    props.setSortableSections(grant.sections);
+    props.setReorderHistory([grant.sections]);
     props.setReorderIndex(0);
   }, [grantId]);
 
   const onUndo = () => {
     if (props.reorderIndex > 0) {
-      console.log("reorderIndex on Undo", props.reorderIndex);
-      props.setSortableSections(props.reorderHistory[props.reorderIndex - 1]);
-      console.log(props.reorderIndex);
+      props.setSortableSections(props.reorderHistory[props.reorderIndex]);
       props.updateState(props.reorderIndex - 1);
+      props.setCanSaveReorder(true);
     }
   };
 
   const onRedo = () => {
     if (
-      props.reorderIndex < props.reorderHistory.length &&
+      props.reorderIndex + 1 < props.reorderHistory.length &&
       props.reorderHistory.length > 1
     ) {
-      console.log("reorderIndex on Redo", props.reorderIndex);
       props.setSortableSections(props.reorderHistory[props.reorderIndex + 1]);
       props.updateState(props.reorderIndex + 1);
-      console.log(props.reorderIndex);
-    } else {
-      props.updateState(0);
-      props.setSortableSections(props.reorderHistory[props.reorderIndex]);
+      props.setCanSaveReorder(true);
     }
   };
 
@@ -95,16 +91,10 @@ export default function GrantShowOverview(props) {
     {
       onSuccess: () => {
         alert("Sections reordered!");
+        props.setCanSaveReorder(false);
       },
     }
   );
-
-  console.log("sortableSections", props.sortableSections);
-  console.log("reorderHistory", props.reorderHistory);
-
-  useEffect(() => {
-    props.setSortableSections(grant.sections);
-  }, []);
 
   if (isLoading) {
     return <span>Loading...</span>;
@@ -152,6 +142,7 @@ export default function GrantShowOverview(props) {
               onClick={() => {
                 grantSectionsReorder();
               }}
+              disabled={!props.canSaveReorder}
             >
               Save
             </Button>
@@ -168,7 +159,7 @@ export default function GrantShowOverview(props) {
                 onRedo();
               }}
               disabled={Boolean(
-                props.reorderIndex === props.reorderHistory.length + 1
+                props.reorderIndex + 1 === props.reorderHistory.length
               )}
             >
               Redo

--- a/src/Components/Grants/GrantShowOverview.jsx
+++ b/src/Components/Grants/GrantShowOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { useQuery, useMutation } from "react-query";
 import { useParams } from "react-router-dom";
 import Button from "../design/Button/Button";
@@ -29,6 +29,15 @@ function countTotalSectionsWords(sections = []) {
 export default function GrantShowOverview(props) {
   const { currentOrganization, organizationClient } = useCurrentOrganization();
   const { grantId } = useParams();
+  const [reorderHistory, setReorderHistory] = useState([]);
+  const [reorderIndex, setReorderIndex] = useState([reorderHistory.length - 1]);
+
+  // useEffect =
+  //   (() => {
+  //   },
+  //   [reorderHistory]);
+
+  console.log(reorderHistory);
 
   const {
     data: grant,
@@ -54,6 +63,23 @@ export default function GrantShowOverview(props) {
     if (sectionsToReorder.length > 0) {
       reorderSections(sectionsToReorder);
     }
+  };
+
+  useEffect(() => {
+    if (props.sortableSections && props.sortableSections.length > 1) {
+      setReorderHistory([...reorderHistory, props.sortableSections]);
+      setReorderIndex(reorderHistory.length - 1);
+    }
+  }, [props.sortableSections]);
+
+  useEffect(() => {
+    setReorderHistory([]);
+    setReorderIndex(reorderHistory.length - 1);
+  }, [grantId]);
+
+  const onUndo = () => {
+    setReorderIndex(reorderIndex - 1);
+    console.log(reorderIndex);
   };
 
   const { mutate: reorderSections } = useMutation(
@@ -122,6 +148,20 @@ export default function GrantShowOverview(props) {
               }}
             >
               Save
+            </Button>
+            <Button
+              onClick={() => {
+                onUndo();
+              }}
+            >
+              Undo
+            </Button>
+            <Button
+              onClick={() => {
+                grantSectionsReorder();
+              }}
+            >
+              Redo
             </Button>
           </div>
           <SortableContext

--- a/src/Components/Grants/GrantShowOverview.jsx
+++ b/src/Components/Grants/GrantShowOverview.jsx
@@ -64,7 +64,7 @@ export default function GrantShowOverview(props) {
 
   const onUndo = () => {
     if (props.reorderIndex > 0) {
-      props.setSortableSections(props.reorderHistory[props.reorderIndex]);
+      props.setSortableSections(props.reorderHistory[props.reorderIndex - 1]);
       props.updateState(props.reorderIndex - 1);
       props.setCanSaveReorder(true);
     }

--- a/src/Components/design/Button/Button.css
+++ b/src/Components/design/Button/Button.css
@@ -87,6 +87,10 @@
   opacity: 0.5;
 }
 
+.button.button--disabled:hover {
+  opacity: 0.5;
+}
+
 .button--none {
   display: inline-block;
   padding: 0;

--- a/src/routes/OrganizationRoutes.jsx
+++ b/src/routes/OrganizationRoutes.jsx
@@ -58,10 +58,13 @@ export default function OrganizationRoutes() {
       const newSectionOrder = (items) => {
         const oldIndex = items.findIndex((item) => item.id === active.id);
         const newIndex = items.findIndex((item) => item.id === over.id);
+        setReorderHistory([
+          ...reorderHistory,
+          arrayMove(items, oldIndex, newIndex),
+        ]);
         return arrayMove(items, oldIndex, newIndex);
       };
       setSortableSections(newSectionOrder);
-      setReorderHistory([...reorderHistory, newSectionOrder]);
       updateState(reorderIndex + 1);
       setCanSaveReorder(true);
     }

--- a/src/routes/OrganizationRoutes.jsx
+++ b/src/routes/OrganizationRoutes.jsx
@@ -40,26 +40,13 @@ export default function OrganizationRoutes() {
   const [activeId, setActiveId] = useState(null);
   const [reorderHistory, setReorderHistory] = useState([]);
   const [reorderIndex, setReorderIndex] = useState(0);
+  const [canSaveReorder, setCanSaveReorder] = useState(false);
   const ref = useRef(reorderIndex);
 
   const updateState = (newState) => {
     ref.current = newState;
     setReorderIndex(newState);
   };
-
-  // const [newIndex, setNewIndex] = useState(props.reorderHistory.length);
-  // const ref = useRef(newIndex);
-  // const [reorderHistory, setReorderHistory] = useState([]);
-  // const [reorderIndex, setReorderIndex] = useState([reorderHistory.length - 1]);
-
-  // console.log(reorderHistory);
-  // console.log(props.reorderHistory.length);
-  // console.log(newIndex);
-
-  // const updateState = (newState) => {
-  //   ref.current = newState;
-  //   setNewIndex(newState);
-  // };
 
   function handleDragStart(event) {
     const { active } = event;
@@ -74,12 +61,9 @@ export default function OrganizationRoutes() {
         return arrayMove(items, oldIndex, newIndex);
       };
       setSortableSections(newSectionOrder);
-      // console.log(reorderHistory.length);
-      // const newLength = reorderHistory.length + 1;
       setReorderHistory([...reorderHistory, newSectionOrder]);
-      // setReorderIndex(newLength);
       updateState(reorderIndex + 1);
-      console.log(reorderIndex);
+      setCanSaveReorder(true);
     }
   }
 
@@ -124,6 +108,8 @@ export default function OrganizationRoutes() {
                     setReorderHistory={setReorderHistory}
                     setReorderIndex={setReorderIndex}
                     updateState={updateState}
+                    canSaveReorder={canSaveReorder}
+                    setCanSaveReorder={setCanSaveReorder}
                   />
                 </DndContext>
               )}

--- a/src/routes/OrganizationRoutes.jsx
+++ b/src/routes/OrganizationRoutes.jsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react";
+import { Suspense, useState, useRef } from "react";
 import { Switch, Route } from "react-router-dom";
 import { CurrentOrganizationProvider } from "../Contexts/currentOrganizationContext";
 import { PasteBoilerplateContentPopoutProvider } from "../Components/PasteBoilerplateContentPopout/PasteBoilerplateContentPopoutContext";
@@ -38,6 +38,28 @@ export default function OrganizationRoutes() {
   const sensors = useSensors(useSensor(PointerSensor));
   const [sortableSections, setSortableSections] = useState([]);
   const [activeId, setActiveId] = useState(null);
+  const [reorderHistory, setReorderHistory] = useState([]);
+  const [reorderIndex, setReorderIndex] = useState(0);
+  const ref = useRef(reorderIndex);
+
+  const updateState = (newState) => {
+    ref.current = newState;
+    setReorderIndex(newState);
+  };
+
+  // const [newIndex, setNewIndex] = useState(props.reorderHistory.length);
+  // const ref = useRef(newIndex);
+  // const [reorderHistory, setReorderHistory] = useState([]);
+  // const [reorderIndex, setReorderIndex] = useState([reorderHistory.length - 1]);
+
+  // console.log(reorderHistory);
+  // console.log(props.reorderHistory.length);
+  // console.log(newIndex);
+
+  // const updateState = (newState) => {
+  //   ref.current = newState;
+  //   setNewIndex(newState);
+  // };
 
   function handleDragStart(event) {
     const { active } = event;
@@ -46,11 +68,18 @@ export default function OrganizationRoutes() {
 
   function handleDragEnd({ active, over }) {
     if (active.id !== over.id) {
-      setSortableSections((items) => {
+      const newSectionOrder = (items) => {
         const oldIndex = items.findIndex((item) => item.id === active.id);
         const newIndex = items.findIndex((item) => item.id === over.id);
         return arrayMove(items, oldIndex, newIndex);
-      });
+      };
+      setSortableSections(newSectionOrder);
+      // console.log(reorderHistory.length);
+      // const newLength = reorderHistory.length + 1;
+      setReorderHistory([...reorderHistory, newSectionOrder]);
+      // setReorderIndex(newLength);
+      updateState(reorderIndex + 1);
+      console.log(reorderIndex);
     }
   }
 
@@ -89,6 +118,12 @@ export default function OrganizationRoutes() {
                     sortableSections={sortableSections}
                     setSortableSections={setSortableSections}
                     activeId={activeId}
+                    handleDragEnd={handleDragEnd}
+                    reorderHistory={reorderHistory}
+                    reorderIndex={reorderIndex}
+                    setReorderHistory={setReorderHistory}
+                    setReorderIndex={setReorderIndex}
+                    updateState={updateState}
                   />
                 </DndContext>
               )}


### PR DESCRIPTION
## 🤺 Summary
This PR closes part of the dnd feature - ticket [#439 ](https://github.com/tuning-fork/boilerplate/issues/439) redo and undo dragging and dropping. The workflow is a little convoluted ticket to ticket - there were some problems with redo/undo, so it had to be reconciled across develop (where 437 was already merged in) and a branch for a subsequent ticket, 442, which adds the preview panel. 

You should be able to:

- navigate to the overview page
- move sections around
- use undo/redo to move up and down the chain of previous section orders
- see undo and redo become disabled/enabled based on your position in the chain - when you're at the beginning, 'undo' should be disabled, and when you're at the end, 'redo' should be disabled
